### PR TITLE
fix: exclude possible vendor packages of another major version

### DIFF
--- a/src/main/webui/src/services/FormUtilsClient.js
+++ b/src/main/webui/src/services/FormUtilsClient.js
@@ -148,7 +148,7 @@ const getExcludes = (languages) => {
       case 'Go':
         return [
           "test/**/*",
-          "vendor/**/*",
+          "**/vendor/**/*",
           "go.mod",
           "go.sum"
         ];


### PR DESCRIPTION
Fixed [APPENG-2769](https://issues.redhat.com/browse/APPENG-2769)

Link to vendor directory of  packages under another major version  ( the commit digest is the one of the input git ref of the above ticket)
https://github.com/openshift/oc-mirror/tree/a0733c17322f96d14f9158604fe74f1bfecc4a53/v2/vendor
