### PR TITLE
chore: upgrade to openshift pipelines 1.17

### DIFF
--- a/.tekton/on-pull-request.yaml
+++ b/.tekton/on-pull-request.yaml
@@ -57,16 +57,23 @@ spec:
     tasks:
       - name: fetch-repository
         taskRef:
-          name: git-clone
+          resolver: cluster
+          params:
+            - name: kind
+              value: task
+            - name: name
+              value: git-clone
+            - name: namespace
+              value: openshift-pipelines
         workspaces:
           - name: output
             workspace: source
           - name: basic-auth
             workspace: basic-auth
         params:
-          - name: url
+          - name: URL
             value: $(params.repo_url)
-          - name: revision
+          - name: REVISION
             value: $(params.revision)
       - name: buildah
         runAfter:
@@ -85,8 +92,14 @@ spec:
             value: >-
               --label=quay.expires-after=$(params.image-expires-after)
         taskRef:
-          kind: ClusterTask
-          name: buildah
+          resolver: cluster
+          params:
+            - name: kind
+              value: task
+            - name: name
+              value: buildah
+            - name: namespace
+              value: openshift-pipelines
         workspaces:
           - name: source
             workspace: source

--- a/.tekton/on-push.yaml
+++ b/.tekton/on-push.yaml
@@ -52,16 +52,23 @@ spec:
     tasks:
       - name: fetch-repository
         taskRef:
-          name: git-clone
+          resolver: cluster
+          params:
+            - name: kind
+              value: task
+            - name: name
+              value: git-clone
+            - name: namespace
+              value: openshift-pipelines
         workspaces:
           - name: output
             workspace: source
           - name: basic-auth
             workspace: basic-auth
         params:
-          - name: url
+          - name: URL
             value: $(params.repo_url)
-          - name: revision
+          - name: REVISION
             value: $(params.revision)
       - name: buildah
         runAfter:
@@ -77,8 +84,14 @@ spec:
             value: >-
               registry.redhat.io/rhel8/buildah@sha256:aac6629389db17e99894c5bee0da01d4c8065d11d8c6f6e1602f9484290baa70
         taskRef:
-          kind: ClusterTask
-          name: buildah
+          resolver: cluster
+          params:
+            - name: kind
+              value: task
+            - name: name
+              value: buildah
+            - name: namespace
+              value: openshift-pipelines
         workspaces:
           - name: source
             workspace: source


### PR DESCRIPTION
`ClusterTasks` have been deprecated in [1.17](https://docs.openshift.com/pipelines/1.17/release_notes/op-release-notes-1-17.html#breaking-changes-1-17_op-release-notes)