### PR TITLE
fix: rename source_info to include and exclude

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/SourceInfo.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/SourceInfo.java
@@ -7,6 +7,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @RegisterForReflection
-public record SourceInfo(String type, @JsonProperty("source_type") String sourceType, @JsonProperty("git_repo") String gitRepo, String ref, Collection<String> includes, Collection<String> excludes) {
+public record SourceInfo(String type, @JsonProperty("source_type") String sourceType, @JsonProperty("git_repo") String gitRepo, String ref, Collection<String> include, Collection<String> exclude) {
   
 }

--- a/src/test/resources/devservices/reports/1cd6c5da-60c9-4f61-83d0-6260d755b0c4.json
+++ b/src/test/resources/devservices/reports/1cd6c5da-60c9-4f61-83d0-6260d755b0c4.json
@@ -31,7 +31,7 @@
           "source_type": "code",
           "git_repo": "https://github.com/openshift/kubernetes-metrics-server",
           "ref": "bcbf241cece8ef455be32a910f1570bae827b4a1",
-          "includes": [
+          "include": [
             "**/*.go",
             "Dockerfile*",
             "docker-compose.yml",
@@ -59,7 +59,7 @@
           "source_type": "doc",
           "git_repo": "https://github.com/openshift/kubernetes-metrics-server",
           "ref": "bcbf241cece8ef455be32a910f1570bae827b4a1",
-          "includes": [
+          "include": [
             "**/*.md",
             "docs/**/*.rst"
           ],

--- a/src/test/resources/devservices/reports/70cef9bf-d3e1-4eae-a264-5eb1a8b3f458.json
+++ b/src/test/resources/devservices/reports/70cef9bf-d3e1-4eae-a264-5eb1a8b3f458.json
@@ -31,7 +31,7 @@
           "source_type": "code",
           "git_repo": "https://github.com/openshift/openshift-controller-manager",
           "ref": "5dcfc990b109d9ae1d8b900655a928c6d859b584",
-          "includes": [
+          "include": [
             "**/*.go"
           ],
           "excludes": [
@@ -46,7 +46,7 @@
           "source_type": "doc",
           "git_repo": "https://github.com/openshift/openshift-controller-manager",
           "ref": "5dcfc990b109d9ae1d8b900655a928c6d859b584",
-          "includes": [
+          "include": [
             "**/*.md",
             "docs/**/*.rst"
           ],

--- a/src/test/resources/devservices/reports/bae675d4-e827-4fb5-b08a-7b7e5066a0f6.json
+++ b/src/test/resources/devservices/reports/bae675d4-e827-4fb5-b08a-7b7e5066a0f6.json
@@ -31,7 +31,7 @@
           "source_type": "code",
           "git_repo": "https://github.com/openshift/console",
           "ref": "350e1eabfd7b20f7ad56032b5a080d0cad4bd835",
-          "includes": [
+          "include": [
             "**/*.ts",
             "**/*.tsx",
             "tsconfig.json",
@@ -110,7 +110,7 @@
           "source_type": "doc",
           "git_repo": "https://github.com/openshift/console",
           "ref": "350e1eabfd7b20f7ad56032b5a080d0cad4bd835",
-          "includes": [
+          "include": [
             "**/*.md",
             "docs/**/*.rst"
           ],

--- a/src/test/resources/devservices/reports/bb50f7ed-76de-4cd6-8638-f93ec78fe8d7.json
+++ b/src/test/resources/devservices/reports/bb50f7ed-76de-4cd6-8638-f93ec78fe8d7.json
@@ -31,7 +31,7 @@
           "source_type": "code",
           "git_repo": "https://github.com/openshift/kubernetes-metrics-server",
           "ref": "8c2920c24c3705e43cefd6c6e65409b7da341ddc",
-          "includes": [
+          "include": [
             "**/*.go",
             "Dockerfile*",
             "docker-compose.yml",
@@ -59,7 +59,7 @@
           "source_type": "doc",
           "git_repo": "https://github.com/openshift/kubernetes-metrics-server",
           "ref": "8c2920c24c3705e43cefd6c6e65409b7da341ddc",
-          "includes": [
+          "include": [
             "**/*.md",
             "docs/**/*.rst"
           ],

--- a/src/test/resources/devservices/reports/c60aa511-eb28-48d6-a591-08a5c5ec020f.json
+++ b/src/test/resources/devservices/reports/c60aa511-eb28-48d6-a591-08a5c5ec020f.json
@@ -31,7 +31,7 @@
           "source_type": "code",
           "git_repo": "https://github.com/openshift/kubernetes-metrics-server",
           "ref": "8c2920c24c3705e43cefd6c6e65409b7da341ddc",
-          "includes": [
+          "include": [
             "**/*.go",
             "Dockerfile*",
             "docker-compose.yml",
@@ -59,7 +59,7 @@
           "source_type": "doc",
           "git_repo": "https://github.com/openshift/kubernetes-metrics-server",
           "ref": "8c2920c24c3705e43cefd6c6e65409b7da341ddc",
-          "includes": [
+          "include": [
             "**/*.md",
             "docs/**/*.rst"
           ],

--- a/src/test/resources/devservices/reports/cf4e5566-2d42-4f07-80bf-76df5fb2ba8b.json
+++ b/src/test/resources/devservices/reports/cf4e5566-2d42-4f07-80bf-76df5fb2ba8b.json
@@ -31,7 +31,7 @@
           "source_type": "code",
           "git_repo": "https://github.com/openshift/azure-file-csi-driver",
           "ref": "15aade4d58785b54ac732a660f1359132d27f9b9",
-          "includes": [
+          "include": [
             "**/*.go",
             "**/*.py",
             "pyproject.toml",
@@ -79,7 +79,7 @@
           "source_type": "doc",
           "git_repo": "https://github.com/openshift/azure-file-csi-driver",
           "ref": "15aade4d58785b54ac732a660f1359132d27f9b9",
-          "includes": [
+          "include": [
             "**/*.md",
             "docs/**/*.rst"
           ],

--- a/src/test/resources/devservices/reports/edc301d5-4450-47dc-aa01-fd204844153e.json
+++ b/src/test/resources/devservices/reports/edc301d5-4450-47dc-aa01-fd204844153e.json
@@ -31,7 +31,7 @@
           "source_type": "code",
           "git_repo": "https://github.com/openshift/kubernetes-metrics-server",
           "ref": "8c2920c24c3705e43cefd6c6e65409b7da341ddc",
-          "includes": [
+          "include": [
             "**/*.go",
             "Dockerfile*",
             "docker-compose.yml",
@@ -59,7 +59,7 @@
           "source_type": "doc",
           "git_repo": "https://github.com/openshift/kubernetes-metrics-server",
           "ref": "8c2920c24c3705e43cefd6c6e65409b7da341ddc",
-          "includes": [
+          "include": [
             "**/*.md",
             "docs/**/*.rst"
           ],

--- a/src/test/resources/devservices/reports/f329e389-c9d0-44bf-8d3e-123cb0ab05e2.json
+++ b/src/test/resources/devservices/reports/f329e389-c9d0-44bf-8d3e-123cb0ab05e2.json
@@ -31,7 +31,7 @@
           "source_type": "code",
           "git_repo": "https://github.com/openshift/console",
           "ref": "f6f61ca06f008ead018f37668f9fa391e668e703",
-          "includes": [
+          "include": [
             "**/*.ts",
             "**/*.tsx",
             "tsconfig.json",
@@ -110,7 +110,7 @@
           "source_type": "doc",
           "git_repo": "https://github.com/openshift/console",
           "ref": "f6f61ca06f008ead018f37668f9fa391e668e703",
-          "includes": [
+          "include": [
             "**/*.md",
             "docs/**/*.rst"
           ],

--- a/src/test/resources/devservices/reports/f4093fbd-1030-4ff0-ba5b-a9289fe113cc.json
+++ b/src/test/resources/devservices/reports/f4093fbd-1030-4ff0-ba5b-a9289fe113cc.json
@@ -31,7 +31,7 @@
           "source_type": "code",
           "git_repo": "https://github.com/openshift/oc-mirror",
           "ref": "a0733c17322f96d14f9158604fe74f1bfecc4a53",
-          "includes": [
+          "include": [
             "**/*.go",
             "**/*.py",
             "pyproject.toml",
@@ -79,7 +79,7 @@
           "source_type": "doc",
           "git_repo": "https://github.com/openshift/oc-mirror",
           "ref": "a0733c17322f96d14f9158604fe74f1bfecc4a53",
-          "includes": [
+          "include": [
             "**/*.md",
             "docs/**/*.rst"
           ],


### PR DESCRIPTION
The vulnerability analysis endpoint is expecting `include` and `exclude` respectively. Using a different name was causing the backend to always use the default patterns 
```
[
  "*.py",
  "*.ipynb"
]
```