### PR TITLE
chore: add expired reports to the UI

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ReportRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ReportRepositoryService.java
@@ -55,7 +55,8 @@ public class ReportRepositoryService {
           Filters.eq("input.scan.completed_at", null)),
       "failed", Filters.ne("error", null),
       "queued", Filters.and(Filters.ne("metadata." + SUBMITTED_AT, null), Filters.eq("metadata." + SENT_AT, null),
-          Filters.eq("error", null), Filters.eq("input.scan.completed_at", null)));
+          Filters.eq("error", null), Filters.eq("input.scan.completed_at", null)),
+      "expired", Filters.and(Filters.ne("error", null),Filters.eq("error.type", "expired")));;
 
   @Inject
   MongoClient mongoClient;
@@ -121,7 +122,7 @@ public class ReportRepositoryService {
   private String getStatus(Document doc, Map<String, String> metadata) {
     if (doc.containsKey("error")) {
       var error = doc.get("error", Document.class);
-      if (error.getString("type").equals("timeout")) {
+      if (error.getString("type").equals("expired")) {
         return "expired";
       }
       return "failed";

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -73,3 +73,5 @@ quarkus.management.enabled=true
 #  /vulnerabilities/.*+=/vulnerabilities/{vuln_id}
 quarkus.micrometer.binder.http-server.ignore-patterns=^(?!/reports|/vulnerabilities).*$
 
+# Queue settings
+morpheus.queue.timeout=10m

--- a/src/main/webui/src/components/ReportsTable.jsx
+++ b/src/main/webui/src/components/ReportsTable.jsx
@@ -153,6 +153,7 @@ export default function ReportsTable() {
   const statusFilter = {
     any: "Any",
     completed: "Completed",
+    expired: "Expired",
     failed: "Failed",
     queued: "Queued",
     sent: "Sent"

--- a/src/main/webui/src/components/StatusLabel.jsx
+++ b/src/main/webui/src/components/StatusLabel.jsx
@@ -1,5 +1,6 @@
 import { Label } from "@patternfly/react-core"
 import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
+import OutlinedClockIcon from '@patternfly/react-icons/dist/esm/icons/outlined-clock-icon';
 
 export const StatusLabel = ({type}) => {
   const msg = String(type).charAt(0).toUpperCase() + String(type).slice(1);
@@ -8,6 +9,7 @@ export const StatusLabel = ({type}) => {
     case "failed": return <Label status="danger">{msg}</Label>
     case "queued": return <Label icon={<InfoCircleIcon />} color="yellow">{msg}</Label>
     case "sent": return <Label status="info">{msg}</Label>
+    case "expired": return <Label color="purple" icon={<OutlinedClockIcon />}>{msg}</Label>;
     default: return <Label color="grey">{msg}</Label>
   }
   


### PR DESCRIPTION
- Increase the default `morpheus.queue.timeout` to 10 minutes, as we've encountered reports that take longer than the previous 5-minute default to process.
- Update the UI to display an `Expired` status.
