### PR TITLE
bug: new reports missing from first page due to default sort

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/ReportEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/ReportEndpoint.java
@@ -98,7 +98,7 @@ public class ReportEndpoint {
   @GET
   public Response list(
       @Context UriInfo uriInfo,
-      @QueryParam(SORT_BY) @DefaultValue("completedAt:DESC") List<String> sortBy,
+      @QueryParam(SORT_BY) @DefaultValue("submittedAt:DESC") List<String> sortBy,
       @QueryParam(PAGE) @DefaultValue("0") Integer page,
       @QueryParam(PAGE_SIZE) @DefaultValue("100") Integer pageSize) {
 

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ReportRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ReportRepositoryService.java
@@ -216,6 +216,7 @@ public class ReportRepositoryService {
 
   private static final Map<String, String> SORT_MAPPINGS = Map.of(
       "completedAt", "input.scan.completed_at",
+      "submittedAt", "metadata.submitted_at",
       "name", "input.scan.id",
       "vuln_id", "output.vuln_id");
 
@@ -233,7 +234,7 @@ public class ReportRepositoryService {
         sorts.add(Sorts.descending(fieldName));
       }
     });
-
+    
     var totalElements = getCollection().countDocuments(filter);
     int totalPages = (int) Math.ceil((double) totalElements / pagination.size());
 

--- a/src/main/webui/src/components/ReportsTable.jsx
+++ b/src/main/webui/src/components/ReportsTable.jsx
@@ -17,7 +17,7 @@ export default function ReportsTable() {
   const { addAlert } = useOutletContext();
   const [reports, setReports] = React.useState([]);
   const [activeSortDirection, setActiveSortDirection] = React.useState('desc');
-  const [activeSortIndex, setActiveSortIndex] = React.useState(2); // Completed At
+  const [activeSortIndex, setActiveSortIndex] = React.useState(3); // Submitted At
   const [page, setPage] = React.useState(1);
   const [perPage, setPerPage] = React.useState(20);
   const [totalElements, setTotalElements] = React.useState(0);
@@ -163,6 +163,7 @@ export default function ReportsTable() {
     { key: 'name', label: 'ID' },
     { key: 'vulns', label: 'CVEs' },
     { key: 'completedAt', label: 'Completed At' },
+    { key: 'submittedAt', label: 'Submitted At' },
     { key: 'state', label: 'State' }
   ];
 
@@ -208,7 +209,8 @@ export default function ReportsTable() {
         </Link><JustificationBanner justification={vuln.justification} /></div>
         })}</Td>
         <Td dataLabel={columnNames[2].label} modifier="nowrap">{r.completedAt ? r.completedAt : '-'}</Td>
-        <Td dataLabel={columnNames[3].label}><StatusLabel type={r.state} /></Td>
+        <Td dataLabel={columnNames[3].label} modifier="nowrap">{r.metadata?.submitted_at || '-'}</Td>
+        <Td dataLabel={columnNames[4].label}><StatusLabel type={r.state} /></Td>
         <Td dataLabel="Actions">
           <Flex columnGap={{ default: 'columnGapSm' }}>
             <Tooltip content="Submit again the report to Morpheus">
@@ -264,7 +266,8 @@ export default function ReportsTable() {
           <Th width={20} sort={getSortParams(0)}>{columnNames[0].label}</Th>
           <Th width={10}>{columnNames[1].label}</Th>
           <Th width={10} sort={getSortParams(2)}>{columnNames[2].label}</Th>
-          <Th>{columnNames[3].label}</Th>
+          <Th width={10} sort={getSortParams(3)}>{columnNames[3].label}</Th>
+          <Th>{columnNames[4].label}</Th>
           <Td>Actions</Td>
         </Tr>
       </Thead>


### PR DESCRIPTION
**Issue:**

Reports initially in `Queued` or `Sent` states were not visible on the first page of the `Vulnerability Reports` table when the default `Any` filter was applied. They would only appear upon changing the filter or navigating to later pages.

**Root Cause:**

The backend API endpoint defaulted the list sorting to `completedAt:DESC`. Reports in early states (`Queued/Sent`) have `input.scan.completed_at` as `null`.

**Solution:**

Change the **default sort order** to `submittedAt:DESC`. This ensures that the most recently submitted reports appear first in the list, making new reports immediately visible on the first page.
The frontend UI default sort column has also been updated to visually reflect sorting by `Submitted At`.

**Verification:**

1.  Submit a new report.
2.  Immediately navigate to the Reports table (or refresh with `Any` filter).
3.  Observe that the newly submitted report is visible on the first page.
4.  Confirm the table headers visually indicate sorting by `Submitted At` descending by default.


Closes https://issues.redhat.com/browse/APPENG-3052