### PR TITLE
Configure image registry credentials

### DIFF
--- a/deploy/agent_morpheus_client.yaml
+++ b/deploy/agent_morpheus_client.yaml
@@ -84,6 +84,20 @@ spec:
                 secretKeyRef:
                   name: agent-morpheus-client-secret
                   key: mongodb.dbname
+            - name: DOCKER_CONFIG
+              value: /tmp/.docker
+          volumeMounts:
+            - name: docker-config
+              readOnly: true
+              mountPath: /tmp/.docker
+      volumes:
+        - name: docker-config
+          secret:
+            secretName: image-registry-credentials
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+            defaultMode: 420
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
In order for `syft` to be able to pull images from image registries and create SBOMs, the container must have access to image registry credentials.