### PR TITLE
chore: make Syft cache path configurable

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/GenerateSbomService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/GenerateSbomService.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -17,6 +18,10 @@ public class GenerateSbomService {
     
     private static final Logger LOGGER = Logger.getLogger(PreProcessingService.class);
     private static final int EXIT_CODE_SUCCESS = 0;
+    private static final String SYFT_CACHE_DIR_ENV = "SYFT_CACHE_DIR";
+
+    @ConfigProperty(name = "morpheus.syft.cache.dir")
+    String syftCacheDir;
 
     @Inject
     ObjectMapper objectMapper;
@@ -31,6 +36,7 @@ public class GenerateSbomService {
             "cyclonedx-json",
         };
         ProcessBuilder pb = new ProcessBuilder(command);
+        pb.environment().put(SYFT_CACHE_DIR_ENV, syftCacheDir);
         Process process = pb.start();
 
         StringBuilder output = new StringBuilder();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -92,3 +92,6 @@ morpheus.queue.timeout=2h
 # Component Syncer settings
 morpheus.syncer.timeout=2h
 
+# Syft settings
+morpheus.syft.cache.dir=${SYFT_CACHE_DIR:/work/.cache/syft}
+


### PR DESCRIPTION
This PR makes the Syft filesystem cache location configurable instead of relying on the default `/.cache/syft`, which caused permission errors when the application runs in containers or non-root environments.

- Added support for configuring the Syft cache directory via the `SYFT_CACHE_DIR` environment variable (or corresponding configuration option).
- Default cache path changed from `/.cache/syft` to a user-writable location when not explicitly set.

Prevents warnings like:

```
WARN unable to get filesystem cache at /.cache/syft: permission denied
```