### PR TITLE
feat: make browser tab title more informative

### DIFF
--- a/openspec/specs/document-titles/spec.md
+++ b/openspec/specs/document-titles/spec.md
@@ -1,0 +1,24 @@
+# document-titles Specification
+
+## Purpose
+Define how the web UI sets `document.title` so tabs show where the user is. Implementation: `src/main/webui/src/pages/pageTitles.ts` and `useDocumentTitle`.
+
+## Requirements
+
+### Requirement: Format and single source
+Tab titles SHALL be built only through `pageTitles.ts` helpers, applied with `useDocumentTitle`, and SHALL end with ` | Exploit Intelligence` (via `withAppTitle` / `DOCUMENT_TITLE_APP_NAME`).
+
+#### Scenario: Conventions
+- **WHEN** any page sets the document title
+- **THEN** it uses `pageTitles.ts` plus `useDocumentTitle` and the string ends with ` | Exploit Intelligence`
+
+### Requirement: Route-specific segments
+Titles SHALL follow the patterns implemented in `pageTitles.ts`, including: Home `Home`; reports list `Reports` vs `Reports — Single repositories`; product report `Report: {productName} / {cveId}` when loaded and `Loading Report: {productId} / {cveId}` while loading; repository report CVE plus image name/tag when loaded; CVE details `CVE: {id}` (uppercased), load errors with CVE id, invalid CVE with optional route segment; excluded components `Excluded components — {product} / {cveId}`; plus error/invalid variants defined in that file.
+
+#### Scenario: Product report loading
+- **WHEN** the product report page is fetching and the route has `productId` and `cveId`
+- **THEN** the document title includes `Loading Report:` with those route values and the app suffix
+
+#### Scenario: CVE details load failure
+- **WHEN** CVE details fail to load for a route CVE id
+- **THEN** the document title includes that CVE id in the error segment with the app suffix

--- a/src/main/webui/src/hooks/useDocumentTitle.ts
+++ b/src/main/webui/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,10 @@
+import { useEffect } from "react";
+
+/**
+ * Sets `document.title` while this component is mounted; updates when `title` changes.
+ */
+export function useDocumentTitle(title: string): void {
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+}

--- a/src/main/webui/src/pages/CveDetailsPage.tsx
+++ b/src/main/webui/src/pages/CveDetailsPage.tsx
@@ -66,16 +66,16 @@ const CveDetailsPage: React.FC = () => {
 
   const documentTitle = useMemo(() => {
     if (!cveId) {
-      return pageTitleCveDetailsInvalid();
+      return pageTitleCveDetailsInvalid(params.cveId);
     }
     if (loading) {
       return pageTitleCveDetails(cveId);
     }
     if (error) {
-      return pageTitleCveDetailsLoadError();
+      return pageTitleCveDetailsLoadError(cveId);
     }
     return pageTitleCveDetails(cveId);
-  }, [cveId, loading, error]);
+  }, [cveId, loading, error, params.cveId]);
 
   useDocumentTitle(documentTitle);
 

--- a/src/main/webui/src/pages/CveDetailsPage.tsx
+++ b/src/main/webui/src/pages/CveDetailsPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useParams, Link } from "react-router";
 import {
   Breadcrumb,
@@ -24,6 +25,12 @@ import CveReferencesCard from "../components/CveReferencesCard";
 import CveVulnerablePackagesCard from "../components/CveVulnerablePackagesCard";
 import CveDescriptionCard from "../components/CveDescriptionCard";
 import CveDetailsPageSkeleton from "../components/CveDetailsPageSkeleton";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
+import {
+  pageTitleCveDetails,
+  pageTitleCveDetailsInvalid,
+  pageTitleCveDetailsLoadError,
+} from "./pageTitles";
 
 interface CveDetailsPageErrorProps {
   title: string;
@@ -54,6 +61,23 @@ const CveDetailsPage: React.FC = () => {
     reportId?: string;
   }>();
   const { productId, cveId, reportId } = params;
+
+  const { metadata, loading, error } = useCveDetails(cveId ?? "", reportId);
+
+  const documentTitle = useMemo(() => {
+    if (!cveId) {
+      return pageTitleCveDetailsInvalid();
+    }
+    if (loading) {
+      return pageTitleCveDetails(cveId);
+    }
+    if (error) {
+      return pageTitleCveDetailsLoadError();
+    }
+    return pageTitleCveDetails(cveId);
+  }, [cveId, loading, error]);
+
+  useDocumentTitle(documentTitle);
 
   if (!cveId) {
     return (
@@ -97,8 +121,6 @@ const CveDetailsPage: React.FC = () => {
       </Breadcrumb>
     );
   };
-
-  const { metadata, loading, error } = useCveDetails(cveId, reportId);
 
   if (loading) {
     return <CveDetailsPageSkeleton />;

--- a/src/main/webui/src/pages/CveDetailsPage.tsx
+++ b/src/main/webui/src/pages/CveDetailsPage.tsx
@@ -30,6 +30,7 @@ import {
   pageTitleCveDetails,
   pageTitleCveDetailsInvalid,
   pageTitleCveDetailsLoadError,
+  pageTitleCveDetailsLoading,
 } from "./pageTitles";
 
 interface CveDetailsPageErrorProps {
@@ -66,16 +67,16 @@ const CveDetailsPage: React.FC = () => {
 
   const documentTitle = useMemo(() => {
     if (!cveId) {
-      return pageTitleCveDetailsInvalid(params.cveId);
+      return pageTitleCveDetailsInvalid();
     }
     if (loading) {
-      return pageTitleCveDetails(cveId);
+      return pageTitleCveDetailsLoading(productId, cveId);
     }
     if (error) {
       return pageTitleCveDetailsLoadError(cveId);
     }
     return pageTitleCveDetails(cveId);
-  }, [cveId, loading, error, params.cveId]);
+  }, [cveId, loading, error, productId]);
 
   useDocumentTitle(documentTitle);
 

--- a/src/main/webui/src/pages/ExcludedComponentsPage.tsx
+++ b/src/main/webui/src/pages/ExcludedComponentsPage.tsx
@@ -28,7 +28,6 @@ import {
   pageTitleExcludedComponents,
   pageTitleExcludedInvalidParams,
   pageTitleExcludedLoadError,
-  pageTitleExcludedNotFound,
 } from "./pageTitles";
 
 const COLUMN_NAMES = {
@@ -70,10 +69,10 @@ const ExcludedComponentsPage: React.FC = () => {
       return pageTitleExcludedComponents(productId, cveId);
     }
     if (error) {
-      return pageTitleExcludedLoadError();
+      return pageTitleExcludedLoadError(productId, cveId);
     }
     if (!data) {
-      return pageTitleExcludedNotFound();
+      return pageTitleExcludedLoadError(productId, cveId);
     }
     const productName = data.data?.name ?? productId;
     return pageTitleExcludedComponents(productName, cveId);

--- a/src/main/webui/src/pages/ExcludedComponentsPage.tsx
+++ b/src/main/webui/src/pages/ExcludedComponentsPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useParams, Link } from "react-router";
 import {
   PageSection,
@@ -22,6 +23,13 @@ import {
 import { useReport } from "../hooks/useReport";
 import { getErrorMessage } from "../utils/errorHandling";
 import TableEmptyState from "../components/TableEmptyState";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
+import {
+  pageTitleExcludedComponents,
+  pageTitleExcludedInvalidParams,
+  pageTitleExcludedLoadError,
+  pageTitleExcludedNotFound,
+} from "./pageTitles";
 
 const COLUMN_NAMES = {
   component: "Component",
@@ -53,6 +61,25 @@ const ExcludedComponentsPageSkeleton: React.FC = () => (
 const ExcludedComponentsPage: React.FC = () => {
   const { productId, cveId } = useParams<{ productId: string; cveId: string }>();
   const { data, loading, error } = useReport(productId);
+
+  const documentTitle = useMemo(() => {
+    if (!productId || !cveId) {
+      return pageTitleExcludedInvalidParams();
+    }
+    if (loading) {
+      return pageTitleExcludedComponents(productId, cveId);
+    }
+    if (error) {
+      return pageTitleExcludedLoadError();
+    }
+    if (!data) {
+      return pageTitleExcludedNotFound();
+    }
+    const productName = data.data?.name ?? productId;
+    return pageTitleExcludedComponents(productName, cveId);
+  }, [productId, cveId, loading, error, data]);
+
+  useDocumentTitle(documentTitle);
 
   if (loading) {
     return <ExcludedComponentsPageSkeleton />;

--- a/src/main/webui/src/pages/HomePage.tsx
+++ b/src/main/webui/src/pages/HomePage.tsx
@@ -13,6 +13,8 @@ import {
 } from "@patternfly/react-core";
 import GetStartedCard from "../components/GetStartedCard";
 import MetricsCard from "../components/MetricsCard";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
+import { PAGE_TITLE_HOME } from "./pageTitles";
 
 const AI_USAGE_ACKNOWLEDGED_KEY = "ai-usage-acknowledged";
 
@@ -21,6 +23,8 @@ const AI_USAGE_ACKNOWLEDGED_KEY = "ai-usage-acknowledged";
  */
 const HomePage: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  useDocumentTitle(PAGE_TITLE_HOME);
 
   useEffect(() => {
     // Check if user has already acknowledged on component mount

--- a/src/main/webui/src/pages/ReportPage.tsx
+++ b/src/main/webui/src/pages/ReportPage.tsx
@@ -24,7 +24,6 @@ import {
   pageTitleReportInvalidParams,
   pageTitleReportLoadError,
   pageTitleReportLoading,
-  pageTitleReportNotFound,
 } from "./pageTitles";
 
 const REPORT_CARD_HEIGHT = "15rem";
@@ -42,10 +41,10 @@ const ReportPage: React.FC = () => {
       return pageTitleReportLoading(productId, cveId);
     }
     if (error) {
-      return pageTitleReportLoadError();
+      return pageTitleReportLoadError(productId, cveId);
     }
     if (!data) {
-      return pageTitleReportNotFound();
+      return pageTitleReportLoadError(productId, cveId);
     }
     return pageTitleProductReport(data.data.name, cveId);
   }, [productId, cveId, loading, error, data]);

--- a/src/main/webui/src/pages/ReportPage.tsx
+++ b/src/main/webui/src/pages/ReportPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useParams, Link } from "react-router";
 import {
   PageSection,
@@ -17,6 +18,14 @@ import ReportComponentStatesPieChart from "../components/ReportComponentStatesPi
 import RepositoryReportsTable from "../components/RepositoryReportsTable";
 import ReportPageSkeleton from "../components/ReportPageSkeleton";
 import { getErrorMessage } from "../utils/errorHandling";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
+import {
+  pageTitleProductReport,
+  pageTitleReportInvalidParams,
+  pageTitleReportLoadError,
+  pageTitleReportLoading,
+  pageTitleReportNotFound,
+} from "./pageTitles";
 
 const REPORT_CARD_HEIGHT = "15rem";
 
@@ -24,6 +33,24 @@ const ReportPage: React.FC = () => {
   const { productId, cveId } = useParams<{ productId: string; cveId: string }>();
 
   const { data, loading, error } = useReport(productId);
+
+  const documentTitle = useMemo(() => {
+    if (!productId || !cveId) {
+      return pageTitleReportInvalidParams();
+    }
+    if (loading) {
+      return pageTitleReportLoading(productId, cveId);
+    }
+    if (error) {
+      return pageTitleReportLoadError();
+    }
+    if (!data) {
+      return pageTitleReportNotFound();
+    }
+    return pageTitleProductReport(data.data.name, cveId);
+  }, [productId, cveId, loading, error, data]);
+
+  useDocumentTitle(documentTitle);
 
   if (loading) {
     return <ReportPageSkeleton />;

--- a/src/main/webui/src/pages/ReportsPage.tsx
+++ b/src/main/webui/src/pages/ReportsPage.tsx
@@ -1,7 +1,20 @@
 import { PageSection, Title } from "@patternfly/react-core";
+import { useLocation } from "react-router";
 import ReportsPageContent from "../components/ReportsPageContent";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
+import {
+  PAGE_TITLE_REPORTS_SBOMS,
+  PAGE_TITLE_REPORTS_SINGLE_REPOSITORIES,
+} from "./pageTitles";
 
 const ReportsPage: React.FC = () => {
+  const location = useLocation();
+  const documentTitle =
+    location.pathname === "/reports/single-repositories"
+      ? PAGE_TITLE_REPORTS_SINGLE_REPOSITORIES
+      : PAGE_TITLE_REPORTS_SBOMS;
+  useDocumentTitle(documentTitle);
+
   return (
     <>
       <PageSection isWidthLimited aria-label="Reports header">

--- a/src/main/webui/src/pages/RepositoryReportPage.tsx
+++ b/src/main/webui/src/pages/RepositoryReportPage.tsx
@@ -24,6 +24,14 @@ import RepositoryReportPageSkeleton from "../components/RepositoryReportPageSkel
 import DownloadDropdown from "../components/DownloadVex";
 import FeedbackReportCard from "../components/FeedbackReportCard";
 import { getReportSummaryForFeedback } from "../utils/feedbackReportSummary";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
+import {
+  pageTitleRepositoryReport,
+  pageTitleRepositoryReportInvalidUrl,
+  pageTitleRepositoryReportLoadError,
+  pageTitleRepositoryReportNotFound,
+  pageTitleRepositoryReportVulnNotFound,
+} from "./pageTitles";
 
 interface RepositoryReportPageErrorProps {
   title: string;
@@ -95,6 +103,32 @@ const RepositoryReportPage: React.FC = () => {
     () => (report ? getReportSummaryForFeedback(report) : ""),
     [report]
   );
+
+  const documentTitle = useMemo(() => {
+    if (!cveId) {
+      return pageTitleRepositoryReportInvalidUrl();
+    }
+    if (loading) {
+      return pageTitleRepositoryReport(cveId);
+    }
+    if (error) {
+      const errorStatus = (error as { status?: number })?.status;
+      return errorStatus === 404
+        ? pageTitleRepositoryReportNotFound(reportId || "")
+        : pageTitleRepositoryReportLoadError();
+    }
+    if (!report) {
+      return pageTitleRepositoryReportNotFound(reportId || "");
+    }
+    const vulnMatch = report.input?.scan?.vulns?.find((v) => v.vuln_id === cveId);
+    if (!vulnMatch) {
+      return pageTitleRepositoryReportVulnNotFound(cveId);
+    }
+    const image = report.input?.image;
+    return pageTitleRepositoryReport(cveId, image?.name, image?.tag);
+  }, [cveId, loading, error, report, reportId]);
+
+  useDocumentTitle(documentTitle);
 
   if (!cveId) {
     return (

--- a/src/main/webui/src/pages/RepositoryReportPage.tsx
+++ b/src/main/webui/src/pages/RepositoryReportPage.tsx
@@ -104,6 +104,11 @@ const RepositoryReportPage: React.FC = () => {
     [report]
   );
 
+  const scanVulnForCve = useMemo(
+    () => report?.input?.scan?.vulns?.find((v) => v.vuln_id === cveId),
+    [report, cveId]
+  );
+
   const documentTitle = useMemo(() => {
     if (!cveId) {
       return pageTitleRepositoryReportInvalidUrl();
@@ -120,13 +125,12 @@ const RepositoryReportPage: React.FC = () => {
     if (!report) {
       return pageTitleRepositoryReportNotFound(reportId || "");
     }
-    const vulnMatch = report.input?.scan?.vulns?.find((v) => v.vuln_id === cveId);
-    if (!vulnMatch) {
+    if (!scanVulnForCve) {
       return pageTitleRepositoryReportVulnNotFound(cveId);
     }
     const image = report.input?.image;
     return pageTitleRepositoryReport(cveId, image?.name, image?.tag);
-  }, [cveId, loading, error, report, reportId]);
+  }, [cveId, loading, error, report, reportId, scanVulnForCve]);
 
   useDocumentTitle(documentTitle);
 
@@ -159,8 +163,7 @@ const RepositoryReportPage: React.FC = () => {
   }
 
   const image = report.input?.image;
-  // Find the vulnerability that matches the CVE ID from the route
-  const vuln = report.input?.scan?.vulns?.find((v) => v.vuln_id === cveId);
+  const vuln = scanVulnForCve;
 
   if (!vuln) {
     return (

--- a/src/main/webui/src/pages/pageTitles.ts
+++ b/src/main/webui/src/pages/pageTitles.ts
@@ -43,6 +43,18 @@ export function pageTitleCveDetails(cveId: string): string {
   return withAppTitle(`CVE: ${cveId.toUpperCase()}`);
 }
 
+/** Document title while CVE metadata is loading (mirrors {@link pageTitleReportLoading}). */
+export function pageTitleCveDetailsLoading(
+  productId: string | undefined,
+  cveId: string
+): string {
+  const cve = cveId.toUpperCase();
+  if (productId) {
+    return withAppTitle(`Loading CVE: ${productId} / ${cve}`);
+  }
+  return withAppTitle(`Loading CVE: ${cve}`);
+}
+
 export function pageTitleExcludedComponents(
   productName: string,
   cveId: string
@@ -70,7 +82,16 @@ export function pageTitleReportInvalidParams(): string {
   return withAppTitle("Invalid report");
 }
 
-export function pageTitleReportLoadError(): string {
+export function pageTitleReportLoadError(
+  productId?: string,
+  cveId?: string
+): string {
+  if (productId && cveId) {
+    return withAppTitle(`Report error — ${productId} / ${cveId}`);
+  }
+  if (productId) {
+    return withAppTitle(`Report error — ${productId}`);
+  }
   return withAppTitle("Report error");
 }
 
@@ -86,21 +107,25 @@ export function pageTitleReportLoading(
 }
 
 export function pageTitleExcludedInvalidParams(): string {
-  return withAppTitle("Invalid excluded components page");
+  return withAppTitle("Excluded components — Missing URL parameters");
 }
 
-export function pageTitleExcludedLoadError(): string {
+export function pageTitleExcludedLoadError(
+  productId?: string,
+  cveId?: string
+): string {
+  if (productId && cveId) {
+    return withAppTitle(`Excluded components error — ${productId} / ${cveId}`);
+  }
+  if (productId) {
+    return withAppTitle(`Excluded components error — ${productId}`);
+  }
   return withAppTitle("Excluded components error");
 }
 
-export function pageTitleExcludedNotFound(): string {
-  return withAppTitle("Product not found");
-}
-
-/** @param routeCveId CVE segment from the route when present (e.g. malformed or empty after trim) */
-export function pageTitleCveDetailsInvalid(routeCveId?: string): string {
-  const id = routeCveId?.trim();
-  return withAppTitle(id ? `Invalid CVE — ${id}` : "Invalid CVE");
+/** CVE details route is incomplete or malformed (e.g. missing CVE segment), not a bad CVE identifier. */
+export function pageTitleCveDetailsInvalid(): string {
+  return withAppTitle("CVE details — Missing or invalid URL");
 }
 
 export function pageTitleCveDetailsLoadError(cveId: string): string {

--- a/src/main/webui/src/pages/pageTitles.ts
+++ b/src/main/webui/src/pages/pageTitles.ts
@@ -82,7 +82,7 @@ export function pageTitleReportLoading(
   productId: string,
   cveId: string
 ): string {
-  return withAppTitle(`Report: ${productId} / ${cveId}`);
+  return withAppTitle(`Loading Report: ${productId} / ${cveId}`);
 }
 
 export function pageTitleExcludedInvalidParams(): string {
@@ -97,10 +97,12 @@ export function pageTitleExcludedNotFound(): string {
   return withAppTitle("Product not found");
 }
 
-export function pageTitleCveDetailsInvalid(): string {
-  return withAppTitle("Invalid CVE");
+/** @param routeCveId CVE segment from the route when present (e.g. malformed or empty after trim) */
+export function pageTitleCveDetailsInvalid(routeCveId?: string): string {
+  const id = routeCveId?.trim();
+  return withAppTitle(id ? `Invalid CVE — ${id}` : "Invalid CVE");
 }
 
-export function pageTitleCveDetailsLoadError(): string {
-  return withAppTitle("CVE details error");
+export function pageTitleCveDetailsLoadError(cveId: string): string {
+  return withAppTitle(`CVE details error — ${cveId.toUpperCase()}`);
 }

--- a/src/main/webui/src/pages/pageTitles.ts
+++ b/src/main/webui/src/pages/pageTitles.ts
@@ -1,0 +1,106 @@
+/**
+ * Central definitions for browser tab (document) titles.
+ * Use {@link withAppTitle} so every tab includes the product name.
+ */
+
+export const DOCUMENT_TITLE_APP_NAME = "Exploit Intelligence";
+
+/** Full tab title: page-specific segment plus app name */
+export function withAppTitle(pageSegment: string): string {
+  return `${pageSegment} | ${DOCUMENT_TITLE_APP_NAME}`;
+}
+
+export const PAGE_TITLE_HOME = withAppTitle("Home");
+
+export const PAGE_TITLE_REPORTS_SBOMS = withAppTitle("Reports");
+
+export const PAGE_TITLE_REPORTS_SINGLE_REPOSITORIES = withAppTitle(
+  "Reports — Single repositories"
+);
+
+export function pageTitleProductReport(
+  productName: string,
+  cveId: string
+): string {
+  return withAppTitle(`Report: ${productName} / ${cveId}`);
+}
+
+/** Repository (CVE) report: CVE plus image/repo identity from the report */
+export function pageTitleRepositoryReport(
+  cveId: string,
+  imageName?: string,
+  imageTag?: string
+): string {
+  const repoParts = [imageName, imageTag].filter(
+    (part): part is string => Boolean(part && part.trim())
+  );
+  const repo = repoParts.join(" ");
+  const segment = repo ? `${cveId} — ${repo}` : cveId;
+  return withAppTitle(segment);
+}
+
+export function pageTitleCveDetails(cveId: string): string {
+  return withAppTitle(`CVE: ${cveId.toUpperCase()}`);
+}
+
+export function pageTitleExcludedComponents(
+  productName: string,
+  cveId: string
+): string {
+  return withAppTitle(`Excluded components — ${productName} / ${cveId}`);
+}
+
+export function pageTitleRepositoryReportInvalidUrl(): string {
+  return withAppTitle("Invalid repository report URL");
+}
+
+export function pageTitleRepositoryReportNotFound(reportId: string): string {
+  return withAppTitle(`Report not found (${reportId})`);
+}
+
+export function pageTitleRepositoryReportLoadError(): string {
+  return withAppTitle("Repository report error");
+}
+
+export function pageTitleRepositoryReportVulnNotFound(cveId: string): string {
+  return withAppTitle(`Vulnerability not found — ${cveId}`);
+}
+
+export function pageTitleReportInvalidParams(): string {
+  return withAppTitle("Invalid report");
+}
+
+export function pageTitleReportLoadError(): string {
+  return withAppTitle("Report error");
+}
+
+export function pageTitleReportNotFound(): string {
+  return withAppTitle("Report not found");
+}
+
+export function pageTitleReportLoading(
+  productId: string,
+  cveId: string
+): string {
+  return withAppTitle(`Report: ${productId} / ${cveId}`);
+}
+
+export function pageTitleExcludedInvalidParams(): string {
+  return withAppTitle("Invalid excluded components page");
+}
+
+export function pageTitleExcludedLoadError(): string {
+  return withAppTitle("Excluded components error");
+}
+
+export function pageTitleExcludedNotFound(): string {
+  return withAppTitle("Product not found");
+}
+
+export function pageTitleCveDetailsInvalid(): string {
+  return withAppTitle("Invalid CVE");
+}
+
+export function pageTitleCveDetailsLoadError(): string {
+  return withAppTitle("CVE details error");
+}


### PR DESCRIPTION
Currently, browser tab title only shows **Exploit Intelligence**.  This PR adds details on the content of the page:

### New files
`src/main/webui/src/pages/pageTitles.ts`
Single place for the app suffix **Exploit Intelligence**, `withAppTitle()`, and all page-specific segments (home, reports tabs, product report, repository/CVE report with CVE + image name/tag, CVE details, excluded components, plus short titles for error/invalid states).

`src/main/webui/src/hooks/useDocumentTitle.ts`
Small hook that sets` document.title` whenever the string changes.

### Behavior
- Home page: Home | Exploit Intelligence
- Reports (/reports): Reports | Exploit Intelligence
- Single repositories tab: Reports — Single repositories | Exploit Intelligence
- Product report: Report: {productName} / {cveId} | Exploit Intelligence (while loading: Report: {productId} / {cveId} | … using URL params)
- Repository report: {cveId} — {imageName} {imageTag} | Exploit Intelligence when the report is loaded; 
while loading, {cveId} | … only;
 dedicated strings for invalid URL, not found, load error, and vuln not found
- CVE details: CVE: {CVEID} | Exploit Intelligence (and invalid/error variants)
- Excluded components: Excluded components — {productName} / {cveId} | Exploit Intelligence
- CveDetailsPage was adjusted so useCveDetails runs before any return, which keeps hook order valid and matches how useCveDetails must be used.

> index.html still has the static <title>Exploit Intelligence</title> for the first paint; as soon as a page mounts, React sets the detailed title.


[Closes ](https://redhat.atlassian.net/issues?filter=106533&selectedIssue=APPENG-4810)