### PR TITLE
chore: add image URL field to repository report page

### DIFF
--- a/openspec/specs/repository-report-page/spec.md
+++ b/openspec/specs/repository-report-page/spec.md
@@ -76,33 +76,15 @@ The repository report page SHALL compare the report status between the previous 
 
 The repository report page SHALL display a Feedback card after the RepositoryAdditionalDetailsCard (Additional Details card) in the same grid only when the report status is "completed".
 
-#### Scenario: Analysis state displayed in DetailsCard
+#### Scenario: CVE repository report details card (DetailsCard)
 - **WHEN** a user views the repository report page with report data loaded
-- **THEN** the DetailsCard displays an "Analysis State" field showing the current state of the report (e.g., "Completed", "Queued", or **Failed** for any failing API status)
-- **AND** the Analysis State field appears as the first field in the DetailsCard description list, immediately after the card title; when status is not **failing**, following fields include CVE, Repository, Commit ID, CVSS Score, Intel Reliability Score, Reason, and Summary; when status is **failing**, **Failure reason** (`report.error.message` only) appears after Analysis State, then CVE (with the same **Failed** label beside the CVE link as in repository findings tables), Repository, and Commit ID, and the Analysis Q&A card is not shown
-- **AND** the analysis state is retrieved from the `status` field in the response object returned by the `/api/v1/reports/{id}` endpoint (the response contains `report` and `status` fields)
-- **AND** the state is displayed using a shared `ReportStatusLabel` React component that renders a PatternFly Label component with appropriate color and icon:
-  - "Completed" state: green label with CheckCircleIcon
-  - "Queued" state: gray label with InProgressIcon (or SyncIcon)
-  - "Sent" state: gray label with InProgressIcon (or SyncIcon)
-  - "Failed" and "Expired" API statuses: both SHALL display the same grey filled **Failed** label with ExclamationCircleIcon as the failed case in `Finding.tsx`; the API may still distinguish `expired` vs `failed`, but this page does not surface `error.type`
-  - Other states: gray label with default styling
-- **AND** except for failing states above, the state text is formatted in title case (first letter uppercase, rest lowercase)
-
-#### Scenario: Analysis state loading state
-- **WHEN** a user views the repository report page
-- **AND** the report data is being fetched from the API
-- **THEN** the DetailsCard displays the "Analysis State" field with a PatternFly Skeleton component in the description area
-- **AND** the Analysis State field appears as the first field in the DetailsCard description list
-- **AND** the Skeleton component indicates that the analysis state is loading
-- **AND** once the report is loaded, the Skeleton is replaced with the `ReportStatusLabel` component showing the actual state from the response's `status` field
-
-#### Scenario: Analysis state fetch error handling
-- **WHEN** a user views the repository report page
-- **AND** the API call to fetch the report fails
-- **THEN** the page displays an appropriate error message based on the error status
-- **AND** if the report fetch succeeds but the `status` field is not present in the response, the DetailsCard displays "Not Available" for the Analysis State field
-- **AND** the Analysis State field appears as the first field in the DetailsCard description list even when displaying "Not Available"
+- **THEN** the `CVE repository report details` card (DetailsCard) displays a description list whose first row is **Finding**, computed from the report API `status` field and the vulnerability analysis justification (same **Failed** presentation as repository findings tables when status is a failing state)
+- **AND** when analysis is in a failing state, **Failure reason** appears next, showing `report.error.message` only
+- **AND** **CVE** is shown as an internal app link to the CVE details route for the current report
+- **AND** **Repository URL** is shown as follows: when the code entry in `report.input.image.source_info` includes both `git_repo` and `ref`, the field is an external link whose URL is the repository base (trim trailing `/`, strip a trailing `.git` suffix, then trim trailing `/` again) followed by `/commit/` and the `ref` value, so the link opens the code snapshot for that revision; the visible link text matches that URL; when only `git_repo` is present, the link targets and displays `git_repo`; when neither is usable, **Not available** is shown
+- **AND** **Image URL** shows the pull reference (for example `registry/repository:tag`, or `registry/repository@sha256:…`) as link text on an external anchor whose `href` is a best-effort HTTPS browse URL for that image (same reference is valid for `podman pull` / `docker pull`); when the report is source-based (for example `analysis_type` is `source` or the image `name` is an `http`/`https` URL), **Not available** is shown
+- **AND** when analysis is not in a failing state, additional rows include CVSS Score, Intel Reliability Score, Reason, and Summary
+- **AND** the Analysis Q&A card (ChecklistCard) is not shown when analysis is in a failing state
 
 #### Scenario: Auto-refresh prevents unnecessary rerenders
 - **WHEN** the repository report page auto-refreshes AND the report status has not changed

--- a/openspec/specs/repository-report-page/spec.md
+++ b/openspec/specs/repository-report-page/spec.md
@@ -32,13 +32,13 @@ The repository report page SHALL display a hierarchical breadcrumb navigation at
 - **THEN** a breadcrumb navigation is displayed at the top of the page with three items:
   - First item: "Reports" displayed as a clickable link that navigates to `/reports` (reports list page)
   - Second item: SBOM Report ID and CVE ID (format: `<product_id>/<CVE ID>`) displayed as a clickable link that navigates to `/reports/product/:productId/:cveId` (SBOM report/CVE report page)
-  - Third item: Report identifier (format: `<CVE ID> | <image name> | <image tag>`) displayed as non-clickable text indicating the current page
+  - Third item: Report identifier (format: `<CVE ID>` and, when the report has a pullable container reference, ` | <pull reference>` such as `registry/repository:tag` or `registry/repository@sha256:…`) displayed as non-clickable text indicating the current page
 
 #### Scenario: Breadcrumb for component route
 - **WHEN** a user views the repository report page at `/reports/component/:cveId/:reportId`
 - **THEN** a breadcrumb navigation is displayed at the top of the page with two items:
   - First item: "Reports" displayed as a clickable link that navigates to `/reports` (reports list page)
-  - Second item: Report identifier (format: `<CVE ID> | <image name> | <image tag>`) displayed as non-clickable text indicating the current page
+  - Second item: Report identifier (same format as the SBOM route’s third item: `<CVE ID>` optionally followed by ` | <pull reference>` when applicable) displayed as non-clickable text indicating the current page
 - **AND** no SBOM report/CVE breadcrumb item is displayed
 
 #### Scenario: Breadcrumb SBOM report ID from report metadata
@@ -52,10 +52,8 @@ The repository report page SHALL display a hierarchical breadcrumb navigation at
 
 #### Scenario: Breadcrumb report identifier from report data
 - **WHEN** a user views the repository report page with report data loaded
-- **THEN** the report identifier breadcrumb item displays in the format `<CVE ID> | <image name> | <image tag>`
-- **AND** the CVE ID is extracted from the vulnerability output matching the route `cveId` parameter (`vuln.vuln_id`)
-- **AND** the image name and tag are extracted from `report.input.image.name` and `report.input.image.tag` respectively
-- **AND** if image name or tag is missing, empty string is used
+- **THEN** the report identifier breadcrumb item displays the CVE ID from the vulnerability matching the route `cveId` parameter (`vuln.vuln_id`)
+- **AND** when the report has a pullable container image reference derived from `report.input.image` (same rules as the **Image** field in the details card: omitted for source-based analysis and non-registry `http`/`https` names), that reference is appended after ` | `; otherwise only the CVE ID is shown (no trailing separators)
 
 #### Scenario: Breadcrumb navigation to reports list
 - **WHEN** a user clicks the "Reports" breadcrumb item on the repository report page
@@ -82,7 +80,7 @@ The repository report page SHALL display a Feedback card after the RepositoryAdd
 - **AND** when analysis is in a failing state, **Failure reason** appears next, showing `report.error.message` only
 - **AND** **CVE** is shown as an internal app link to the CVE details route for the current report
 - **AND** **Repository URL** is shown as follows: when the code entry in `report.input.image.source_info` includes both `git_repo` and `ref`, the field is an external link whose URL is the repository base (trim trailing `/`, strip a trailing `.git` suffix, then trim trailing `/` again) followed by `/commit/` and the `ref` value, so the link opens the code snapshot for that revision; the visible link text matches that URL; when only `git_repo` is present, the link targets and displays `git_repo`; when neither is usable, **Not available** is shown
-- **AND** **Image URL** shows the pull reference (for example `registry/repository:tag`, or `registry/repository@sha256:…`) as link text on an external anchor whose `href` is a best-effort HTTPS browse URL for that image (same reference is valid for `podman pull` / `docker pull`); when the report is source-based (for example `analysis_type` is `source` or the image `name` is an `http`/`https` URL), **Not available** is shown
+- **AND** **Image** shows the pull reference (for example `registry/repository:tag`, or `registry/repository@sha256:…`) as plain text suitable for any OCI-compatible `pull` command when the report has a pullable container reference; when the report is source-based (for example `analysis_type` is `source` or the image `name` is an `http`/`https` URL that is not a registry reference), **Not available** is shown; the value is not a hyperlink
 - **AND** when analysis is not in a failing state, additional rows include CVSS Score, Intel Reliability Score, Reason, and Summary
 - **AND** the Analysis Q&A card (ChecklistCard) is not shown when analysis is in a failing state
 

--- a/openspec/specs/repository-report-page/spec.md
+++ b/openspec/specs/repository-report-page/spec.md
@@ -32,13 +32,13 @@ The repository report page SHALL display a hierarchical breadcrumb navigation at
 - **THEN** a breadcrumb navigation is displayed at the top of the page with three items:
   - First item: "Reports" displayed as a clickable link that navigates to `/reports` (reports list page)
   - Second item: SBOM Report ID and CVE ID (format: `<product_id>/<CVE ID>`) displayed as a clickable link that navigates to `/reports/product/:productId/:cveId` (SBOM report/CVE report page)
-  - Third item: Report identifier (format: `<CVE ID>` and, when the report has a pullable container reference, ` | <pull reference>` such as `registry/repository:tag` or `registry/repository@sha256:…`) displayed as non-clickable text indicating the current page
+  - Third item: Report identifier (format: `<CVE ID> | <image name> | <image tag>`) displayed as non-clickable text indicating the current page
 
 #### Scenario: Breadcrumb for component route
 - **WHEN** a user views the repository report page at `/reports/component/:cveId/:reportId`
 - **THEN** a breadcrumb navigation is displayed at the top of the page with two items:
   - First item: "Reports" displayed as a clickable link that navigates to `/reports` (reports list page)
-  - Second item: Report identifier (same format as the SBOM route’s third item: `<CVE ID>` optionally followed by ` | <pull reference>` when applicable) displayed as non-clickable text indicating the current page
+  - Second item: Report identifier (format: `<CVE ID> | <image name> | <image tag>`) displayed as non-clickable text indicating the current page
 - **AND** no SBOM report/CVE breadcrumb item is displayed
 
 #### Scenario: Breadcrumb SBOM report ID from report metadata
@@ -52,8 +52,10 @@ The repository report page SHALL display a hierarchical breadcrumb navigation at
 
 #### Scenario: Breadcrumb report identifier from report data
 - **WHEN** a user views the repository report page with report data loaded
-- **THEN** the report identifier breadcrumb item displays the CVE ID from the vulnerability matching the route `cveId` parameter (`vuln.vuln_id`)
-- **AND** when the report has a pullable container image reference derived from `report.input.image` (same rules as the **Image** field in the details card: omitted for source-based analysis and non-registry `http`/`https` names), that reference is appended after ` | `; otherwise only the CVE ID is shown (no trailing separators)
+- **THEN** the report identifier breadcrumb item displays in the format `<CVE ID> | <image name> | <image tag>`
+- **AND** the CVE ID is extracted from the vulnerability output matching the route `cveId` parameter (`vuln.vuln_id`)
+- **AND** the image name and tag are extracted from `report.input.image.name` and `report.input.image.tag` respectively
+- **AND** if image name or tag is missing, empty string is used
 
 #### Scenario: Breadcrumb navigation to reports list
 - **WHEN** a user clicks the "Reports" breadcrumb item on the repository report page

--- a/src/main/webui/src/components/DetailsCard.tsx
+++ b/src/main/webui/src/components/DetailsCard.tsx
@@ -17,10 +17,7 @@ import Finding from "./Finding";
 import IntelReliabilityScore from "./IntelReliabilityScore";
 import NotAvailable from "./NotAvailable";
 import { getFindingForReportRow } from "../utils/findingDisplay";
-import {
-  podmanPullImageReference,
-  containerImageBrowseUrl,
-} from "../utils/containerImageReference";
+import { getPullImageReference } from "../utils/containerImageReference";
 
 /** Base URL for .../commit/{ref} links: no trailing slash or `.git` suffix. */
 function normalizeRepoBaseForCommitLink(repo: string): string {
@@ -67,7 +64,7 @@ const DetailsCard: React.FC<DetailsCardProps> = ({
     codeRepository && codeRef
       ? `${normalizeRepoBaseForCommitLink(codeRepository)}/commit/${codeRef}`
       : undefined;
-  const imagePullRef = podmanPullImageReference(image);
+  const imagePullRef = getPullImageReference(image);
   const output = report.output?.analysis || [];
   const vuln = report.input?.scan?.vulns?.find((v) => v.vuln_id === cveId);
   const outputVuln = output.find((v) => v.vuln_id === cveId);
@@ -135,20 +132,9 @@ const DetailsCard: React.FC<DetailsCardProps> = ({
               </DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>
-              <DescriptionListTerm>Image URL</DescriptionListTerm>
+              <DescriptionListTerm>Image</DescriptionListTerm>
               <DescriptionListDescription>
-                {imagePullRef ? (
-                  <Content
-                    component="a"
-                    href={containerImageBrowseUrl(imagePullRef)}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    {imagePullRef}
-                  </Content>
-                ) : (
-                  <NotAvailable />
-                )}
+                {imagePullRef ?? <NotAvailable />}
               </DescriptionListDescription>
             </DescriptionListGroup>
             {!isFailed && (

--- a/src/main/webui/src/components/DetailsCard.tsx
+++ b/src/main/webui/src/components/DetailsCard.tsx
@@ -17,6 +17,10 @@ import Finding from "./Finding";
 import IntelReliabilityScore from "./IntelReliabilityScore";
 import NotAvailable from "./NotAvailable";
 import { getFindingForReportRow } from "../utils/findingDisplay";
+import {
+  podmanPullImageReference,
+  containerImageBrowseUrl,
+} from "../utils/containerImageReference";
 
 /** Base URL for .../commit/{ref} links: no trailing slash or `.git` suffix. */
 function normalizeRepoBaseForCommitLink(repo: string): string {
@@ -58,7 +62,12 @@ const DetailsCard: React.FC<DetailsCardProps> = ({
     ? sourceInfo.find((s) => s?.type === "code")
     : undefined;
   const codeRepository = codeSource?.git_repo;
-  const codeTag = codeSource?.ref;
+  const codeRef = codeSource?.ref;
+  const repositorySnapshotUrl =
+    codeRepository && codeRef
+      ? `${normalizeRepoBaseForCommitLink(codeRepository)}/commit/${codeRef}`
+      : undefined;
+  const imagePullRef = podmanPullImageReference(image);
   const output = report.output?.analysis || [];
   const vuln = report.input?.scan?.vulns?.find((v) => v.vuln_id === cveId);
   const outputVuln = output.find((v) => v.vuln_id === cveId);
@@ -106,9 +115,17 @@ const DetailsCard: React.FC<DetailsCardProps> = ({
               </DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>
-              <DescriptionListTerm>Repository</DescriptionListTerm>
+              <DescriptionListTerm>Repository URL</DescriptionListTerm>
               <DescriptionListDescription>
-                {codeRepository ? (
+                {repositorySnapshotUrl ? (
+                  <a
+                    href={repositorySnapshotUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {repositorySnapshotUrl}
+                  </a>
+                ) : codeRepository ? (
                   <a href={codeRepository} target="_blank" rel="noreferrer">
                     {codeRepository}
                   </a>
@@ -118,16 +135,17 @@ const DetailsCard: React.FC<DetailsCardProps> = ({
               </DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>
-              <DescriptionListTerm>Commit ID</DescriptionListTerm>
+              <DescriptionListTerm>Image URL</DescriptionListTerm>
               <DescriptionListDescription>
-                {codeRepository && codeTag ? (
-                  <a
-                    href={`${normalizeRepoBaseForCommitLink(codeRepository)}/commit/${codeTag}`}
+                {imagePullRef ? (
+                  <Content
+                    component="a"
+                    href={containerImageBrowseUrl(imagePullRef)}
                     target="_blank"
                     rel="noreferrer"
                   >
-                    {codeTag}
-                  </a>
+                    {imagePullRef}
+                  </Content>
                 ) : (
                   <NotAvailable />
                 )}

--- a/src/main/webui/src/mocks/handlers.ts
+++ b/src/main/webui/src/mocks/handlers.ts
@@ -698,6 +698,175 @@ const mockReports: Report[] = [
   }),
 ];
 
+/** Reports with no `product_id` / `productId` in metadata (MSW mirror of `withoutProduct=true`). */
+const mockSingleRepositoryReports: Report[] = [
+  {
+    id: "sr-msw-1",
+    scanId: "sr-msw-1",
+    startedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+    completedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+    imageName: "source",
+    imageTag: "n/a",
+    state: "completed",
+    vulns: [
+      {
+        vulnId: "CVE-2024-SINGLE1",
+        justification: { status: "FALSE", label: "not_vulnerable" },
+      },
+    ],
+    metadata: {
+      environment: "msw-single",
+      submitted_at: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+    gitRepo: "https://github.com/msw-examples/single-repo-service",
+    ref: "a1b2c3d4e5f6789012345678901234567890abcd",
+    submittedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "sr-msw-2",
+    scanId: "sr-msw-2",
+    startedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    completedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+    imageName: "source",
+    imageTag: "n/a",
+    state: "completed",
+    vulns: [
+      {
+        vulnId: "CVE-2024-SINGLE2",
+        justification: { status: "TRUE", label: "vulnerable" },
+      },
+    ],
+    metadata: {
+      environment: "msw-single",
+      submitted_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+    gitRepo: "https://github.com/msw-examples/single-repo-app-two",
+    ref: "b2c3d4e5f6789012345678901234567890abcdef12",
+    submittedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "sr-msw-3",
+    scanId: "sr-msw-3",
+    startedAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+    completedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    imageName: "source",
+    imageTag: "n/a",
+    state: "completed",
+    vulns: [
+      {
+        vulnId: "CVE-2024-SINGLE3",
+        justification: { status: "UNKNOWN", label: "uncertain" },
+      },
+    ],
+    metadata: {
+      environment: "msw-single",
+      submitted_at: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+    gitRepo: "https://github.com/msw-examples/single-repo-three",
+    ref: "c3d4e5f6789012345678901234567890abcdef1234",
+    submittedAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "sr-msw-4",
+    scanId: "sr-msw-4",
+    startedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    completedAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+    imageName: "source",
+    imageTag: "n/a",
+    state: "completed",
+    vulns: [
+      {
+        vulnId: "CVE-2024-SINGLE4",
+        justification: { status: "FALSE", label: "not_vulnerable" },
+      },
+    ],
+    metadata: {
+      environment: "msw-single",
+      submitted_at: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+    gitRepo: "https://github.com/msw-examples/single-repo-four",
+    ref: "d4e5f6789012345678901234567890abcdef123456",
+    submittedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "sr-msw-5",
+    scanId: "sr-msw-5",
+    startedAt: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+    completedAt: "",
+    imageName: "source",
+    imageTag: "n/a",
+    state: "sent",
+    vulns: [
+      {
+        vulnId: "CVE-2024-SINGLE5",
+        justification: { status: "UNKNOWN", label: "uncertain" },
+      },
+    ],
+    metadata: {
+      environment: "msw-single",
+      submitted_at: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+      sent_at: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+    gitRepo: "https://github.com/msw-examples/single-repo-five",
+    ref: "e5f6789012345678901234567890abcdef12345678",
+    submittedAt: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "sr-msw-6",
+    scanId: "sr-msw-6",
+    startedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+    completedAt: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+    imageName: "source",
+    imageTag: "n/a",
+    state: "completed",
+    vulns: [
+      {
+        vulnId: "CVE-2024-SINGLE6",
+        justification: { status: "FALSE", label: "not_vulnerable" },
+      },
+    ],
+    metadata: {
+      environment: "msw-single",
+      submitted_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+    gitRepo: "https://github.com/msw-examples/single-repo-six",
+    ref: "f6789012345678901234567890abcdef1234567890",
+    submittedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+];
+
+function reportHasProductMetadata(r: Report): boolean {
+  const m = r.metadata ?? {};
+  return Boolean(m.productId || m.product_id);
+}
+
+function findReportByScanId(scanId: string): Report | undefined {
+  return (
+    mockReports.find((r) => r.scanId === scanId) ??
+    mockSingleRepositoryReports.find((r) => r.scanId === scanId)
+  );
+}
+
+function findReportById(id: string): Report | undefined {
+  return (
+    mockReports.find((r) => r.id === id) ??
+    mockSingleRepositoryReports.find((r) => r.id === id)
+  );
+}
+
+function removeReportById(id: string): boolean {
+  const iMain = mockReports.findIndex((r) => r.id === id);
+  if (iMain !== -1) {
+    mockReports.splice(iMain, 1);
+    return true;
+  }
+  const iSingle = mockSingleRepositoryReports.findIndex((r) => r.id === id);
+  if (iSingle !== -1) {
+    mockSingleRepositoryReports.splice(iSingle, 1);
+    return true;
+  }
+  return false;
+}
 
 /**
  * MSW request handlers
@@ -790,13 +959,17 @@ export const handlers = [
     const vulnId = url.searchParams.get("vulnId");
     const status = url.searchParams.get("status");
 
-    let filteredReports = [...mockReports];
+    let filteredReports = [...mockReports, ...mockSingleRepositoryReports];
 
     // Apply filters
     if (productId) {
       filteredReports = filteredReports.filter(
-        (r) => r.metadata?.productId === productId // Note: Will be productId when types are updated
+        (r) =>
+          r.metadata?.productId === productId ||
+          r.metadata?.product_id === productId
       );
+    } else if (url.searchParams.get("withoutProduct") === "true") {
+      filteredReports = filteredReports.filter((r) => !reportHasProductMetadata(r));
     }
 
     if (vulnId) {
@@ -831,7 +1004,7 @@ export const handlers = [
   http.get("/api/v1/reports/by-scan-id/:scanId", async ({ request, params }) => {
     await delay(getMockDelay(request));
     const { scanId } = params as { scanId: string };
-    const report = mockReports.find((r) => r.scanId === scanId);
+    const report = findReportByScanId(scanId);
     if (!report) {
       return HttpResponse.json({ error: "Report not found" }, { status: 404 });
     }
@@ -890,7 +1063,7 @@ export const handlers = [
     }
 
     // Fallback to Report summary if no FullReport exists
-    const report = mockReports.find((r) => r.id === id);
+    const report = findReportById(id);
     if (!report) {
       return HttpResponse.json({ error: "Report not found" }, { status: 404 });
     }
@@ -953,14 +1126,12 @@ export const handlers = [
   // DELETE /api/v1/reports/:id - Delete analysis report
   http.delete("/api/v1/reports/:id", async ({ request, params }) => {
     await delay(getMockDelay(request));
-    const { id } = params;
-    const index = mockReports.findIndex((r) => r.id === id);
+    const { id } = params as { id: string };
 
-    if (index === -1) {
+    if (!removeReportById(id)) {
       return HttpResponse.json({ error: "Report not found" }, { status: 404 });
     }
 
-    mockReports.splice(index, 1);
     return HttpResponse.json({ message: "Report deleted successfully" });
   }),
 
@@ -1003,8 +1174,8 @@ export const handlers = [
   // POST /api/v1/reports/:id/submit - Submit to ExploitIQ
   http.post("/api/v1/reports/:id/submit", async ({ request, params }) => {
     await delay(getMockDelay(request));
-    const { id } = params;
-    const report = mockReports.find((r) => r.id === id);
+    const { id } = params as { id: string };
+    const report = findReportById(id);
 
     if (!report) {
       return HttpResponse.json({ error: "Report not found" }, { status: 404 });
@@ -1019,8 +1190,8 @@ export const handlers = [
   // POST /api/reports/:id/retry - Retry analysis request
   http.post("/api/reports/:id/retry", async ({ request, params }) => {
     await delay(getMockDelay(request));
-    const { id } = params;
-    const report = mockReports.find((r) => r.id === id);
+    const { id } = params as { id: string };
+    const report = findReportById(id);
 
     if (!report) {
       return HttpResponse.json({ error: "Request not found" }, { status: 404 });

--- a/src/main/webui/src/mocks/mockFullReports.ts
+++ b/src/main/webui/src/mocks/mockFullReports.ts
@@ -2522,4 +2522,383 @@ export const mockFullReports: Record<string, FullReport> = {
       team: "demo",
     },
   },
+
+  /** MSW single-repository list (no product): source scan — Image row is N/A in UI */
+  "sr-msw-1": {
+    _id: "sr-msw-1",
+    input: {
+      scan: {
+        id: "sr-msw-1",
+        type: "source",
+        started_at: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+        completed_at: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+        vulns: [
+          {
+            vuln_id: "CVE-2024-SINGLE1",
+            description: "MSW single-repo mock vulnerability",
+            score: 6.1,
+            severity: "MEDIUM",
+            published_date: "2024-06-01",
+            last_modified_date: "2024-06-15",
+            url: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-SINGLE1",
+            feed_group: "nvd",
+            package: "example-lib",
+            package_version: "2.0.0",
+            package_name: "example-lib",
+            package_type: "maven",
+          },
+        ],
+      },
+      image: {
+        analysis_type: "source",
+        ecosystem: "java",
+        name: "https://github.com/msw-examples/single-repo-service",
+        tag: "a1b2c3d4e5f6789012345678901234567890abcd",
+        source_info: [
+          {
+            type: "code",
+            git_repo: "https://github.com/msw-examples/single-repo-service",
+            ref: "a1b2c3d4e5f6789012345678901234567890abcd",
+            include: ["**/*.java"],
+            exclude: ["target/**"],
+          },
+        ],
+      },
+    },
+    output: {
+      analysis: [
+        {
+          vuln_id: "CVE-2024-SINGLE1",
+          justification: {
+            status: "FALSE",
+            label: "not_vulnerable",
+            reason: "Mock analysis: not exploitable in this codebase.",
+          },
+          summary: "MSW mock source repository report.",
+          checklist: [],
+          intel_score: 0.5,
+          cvss: {
+            score: "6.1",
+            vector_string: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L",
+          },
+        },
+      ],
+      vex: null,
+    },
+    info: {},
+    metadata: {
+      submitted_at: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+      environment: "msw-single",
+    },
+  },
+  "sr-msw-2": {
+    _id: "sr-msw-2",
+    input: {
+      scan: {
+        id: "sr-msw-2",
+        type: "source",
+        started_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+        completed_at: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+        vulns: [
+          {
+            vuln_id: "CVE-2024-SINGLE2",
+            description: "MSW single-repo mock vulnerability 2",
+            score: 7.2,
+            severity: "HIGH",
+            published_date: "2024-05-10",
+            last_modified_date: "2024-05-20",
+            url: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-SINGLE2",
+            feed_group: "nvd",
+            package: "another-lib",
+            package_version: "1.1.0",
+            package_name: "another-lib",
+            package_type: "maven",
+          },
+        ],
+      },
+      image: {
+        analysis_type: "source",
+        ecosystem: "java",
+        name: "https://github.com/msw-examples/single-repo-app-two",
+        tag: "b2c3d4e5f6789012345678901234567890abcdef12",
+        source_info: [
+          {
+            type: "code",
+            git_repo: "https://github.com/msw-examples/single-repo-app-two",
+            ref: "b2c3d4e5f6789012345678901234567890abcdef12",
+          },
+        ],
+      },
+    },
+    output: {
+      analysis: [
+        {
+          vuln_id: "CVE-2024-SINGLE2",
+          justification: {
+            status: "TRUE",
+            label: "vulnerable",
+            reason: "Mock: dependency is in scope.",
+          },
+          summary: "MSW mock source report 2.",
+          checklist: [],
+          intel_score: 0.6,
+          cvss: {
+            score: "7.2",
+            vector_string: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+          },
+        },
+      ],
+      vex: null,
+    },
+    info: {},
+    metadata: {
+      submitted_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+      environment: "msw-single",
+    },
+  },
+  "sr-msw-3": {
+    _id: "sr-msw-3",
+    input: {
+      scan: {
+        id: "sr-msw-3",
+        type: "source",
+        started_at: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+        completed_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+        vulns: [
+          {
+            vuln_id: "CVE-2024-SINGLE3",
+            description: "MSW single-repo mock vulnerability 3",
+            score: 5.5,
+            severity: "MEDIUM",
+            published_date: "2024-04-01",
+            last_modified_date: "2024-04-10",
+            url: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-SINGLE3",
+            feed_group: "nvd",
+            package: "lib-three",
+            package_version: "3.0.0",
+            package_name: "lib-three",
+            package_type: "maven",
+          },
+        ],
+      },
+      image: {
+        analysis_type: "source",
+        ecosystem: "java",
+        name: "https://github.com/msw-examples/single-repo-three",
+        tag: "c3d4e5f6789012345678901234567890abcdef1234",
+        source_info: [
+          {
+            type: "code",
+            git_repo: "https://github.com/msw-examples/single-repo-three",
+            ref: "c3d4e5f6789012345678901234567890abcdef1234",
+          },
+        ],
+      },
+    },
+    output: {
+      analysis: [
+        {
+          vuln_id: "CVE-2024-SINGLE3",
+          justification: {
+            status: "UNKNOWN",
+            label: "uncertain",
+            reason: "Mock: insufficient context.",
+          },
+          summary: "MSW mock source report 3.",
+          checklist: [],
+          intel_score: 0.4,
+          cvss: {
+            score: "5.5",
+            vector_string: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N",
+          },
+        },
+      ],
+      vex: null,
+    },
+    info: {},
+    metadata: {
+      submitted_at: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+      environment: "msw-single",
+    },
+  },
+  "sr-msw-4": {
+    _id: "sr-msw-4",
+    input: {
+      scan: {
+        id: "sr-msw-4",
+        type: "source",
+        started_at: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+        completed_at: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+        vulns: [
+          {
+            vuln_id: "CVE-2024-SINGLE4",
+            description: "MSW single-repo mock vulnerability 4",
+            score: 4.0,
+            severity: "LOW",
+            published_date: "2024-03-01",
+            last_modified_date: "2024-03-05",
+            url: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-SINGLE4",
+            feed_group: "nvd",
+            package: "lib-four",
+            package_version: "1.0.1",
+            package_name: "lib-four",
+            package_type: "maven",
+          },
+        ],
+      },
+      image: {
+        analysis_type: "source",
+        ecosystem: "java",
+        name: "https://github.com/msw-examples/single-repo-four",
+        tag: "d4e5f6789012345678901234567890abcdef123456",
+        source_info: [
+          {
+            type: "code",
+            git_repo: "https://github.com/msw-examples/single-repo-four",
+            ref: "d4e5f6789012345678901234567890abcdef123456",
+          },
+        ],
+      },
+    },
+    output: {
+      analysis: [
+        {
+          vuln_id: "CVE-2024-SINGLE4",
+          justification: {
+            status: "FALSE",
+            label: "not_vulnerable",
+            reason: "Mock: not applicable.",
+          },
+          summary: "MSW mock source report 4.",
+          checklist: [],
+          intel_score: 0.3,
+          cvss: {
+            score: "4.0",
+            vector_string: "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N",
+          },
+        },
+      ],
+      vex: null,
+    },
+    info: {},
+    metadata: {
+      submitted_at: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+      environment: "msw-single",
+    },
+  },
+  "sr-msw-5": {
+    _id: "sr-msw-5",
+    input: {
+      scan: {
+        id: "sr-msw-5",
+        type: "source",
+        started_at: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+        completed_at: "",
+        vulns: [
+          {
+            vuln_id: "CVE-2024-SINGLE5",
+            description: "MSW single-repo mock vulnerability 5 (in progress)",
+            score: 8.0,
+            severity: "HIGH",
+            published_date: "2024-02-01",
+            last_modified_date: "2024-02-10",
+            url: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-SINGLE5",
+            feed_group: "nvd",
+            package: "lib-five",
+            package_version: "5.0.0",
+            package_name: "lib-five",
+            package_type: "maven",
+          },
+        ],
+      },
+      image: {
+        analysis_type: "source",
+        ecosystem: "java",
+        name: "https://github.com/msw-examples/single-repo-five",
+        tag: "e5f6789012345678901234567890abcdef12345678",
+        source_info: [
+          {
+            type: "code",
+            git_repo: "https://github.com/msw-examples/single-repo-five",
+            ref: "e5f6789012345678901234567890abcdef12345678",
+          },
+        ],
+      },
+    },
+    output: {
+      analysis: [],
+      vex: null,
+    },
+    info: {},
+    metadata: {
+      submitted_at: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+      sent_at: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+      environment: "msw-single",
+    },
+  },
+  "sr-msw-6": {
+    _id: "sr-msw-6",
+    input: {
+      scan: {
+        id: "sr-msw-6",
+        type: "source",
+        started_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+        completed_at: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+        vulns: [
+          {
+            vuln_id: "CVE-2024-SINGLE6",
+            description: "MSW single-repo mock vulnerability 6",
+            score: 3.3,
+            severity: "LOW",
+            published_date: "2024-01-10",
+            last_modified_date: "2024-01-12",
+            url: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-SINGLE6",
+            feed_group: "nvd",
+            package: "lib-six",
+            package_version: "0.9.0",
+            package_name: "lib-six",
+            package_type: "maven",
+          },
+        ],
+      },
+      image: {
+        analysis_type: "source",
+        ecosystem: "java",
+        name: "https://github.com/msw-examples/single-repo-six",
+        tag: "f6789012345678901234567890abcdef1234567890",
+        source_info: [
+          {
+            type: "code",
+            git_repo: "https://github.com/msw-examples/single-repo-six",
+            ref: "f6789012345678901234567890abcdef1234567890",
+          },
+        ],
+      },
+    },
+    output: {
+      analysis: [
+        {
+          vuln_id: "CVE-2024-SINGLE6",
+          justification: {
+            status: "FALSE",
+            label: "not_vulnerable",
+            reason: "Mock: patched upstream.",
+          },
+          summary: "MSW mock source report 6.",
+          checklist: [],
+          intel_score: 0.2,
+          cvss: {
+            score: "3.3",
+            vector_string: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+          },
+        },
+      ],
+      vex: null,
+    },
+    info: {},
+    metadata: {
+      submitted_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+      environment: "msw-single",
+    },
+  },
 };

--- a/src/main/webui/src/pages/RepositoryReportPage.tsx
+++ b/src/main/webui/src/pages/RepositoryReportPage.tsx
@@ -24,7 +24,6 @@ import RepositoryReportPageSkeleton from "../components/RepositoryReportPageSkel
 import DownloadDropdown from "../components/DownloadVex";
 import FeedbackReportCard from "../components/FeedbackReportCard";
 import { getReportSummaryForFeedback } from "../utils/feedbackReportSummary";
-import { getPullImageReference } from "../utils/containerImageReference";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import {
   pageTitleRepositoryReport,
@@ -175,9 +174,8 @@ const RepositoryReportPage: React.FC = () => {
     );
   }
 
-  const pullableImageRef = getPullImageReference(image);
   const reportIdDisplay = vuln.vuln_id
-    ? [vuln.vuln_id, pullableImageRef].filter(Boolean).join(" | ")
+    ? `${vuln.vuln_id} | ${image?.name || ""} | ${image?.tag || ""}`
     : "";
   // Extract product name from metadata, fallback to productId
   const productName = report?.metadata?.product_id;
@@ -203,7 +201,7 @@ const RepositoryReportPage: React.FC = () => {
                     fontSize: "var(--pf-t--global--font--size--heading--h6)",
                   }}
                 >
-                  {[cveId, pullableImageRef].filter(Boolean).join(" | ")}
+                  {cveId} | {image?.name || ""} | {image?.tag || ""}
                 </span>
               </Title>
             </FlexItem>

--- a/src/main/webui/src/pages/RepositoryReportPage.tsx
+++ b/src/main/webui/src/pages/RepositoryReportPage.tsx
@@ -24,6 +24,7 @@ import RepositoryReportPageSkeleton from "../components/RepositoryReportPageSkel
 import DownloadDropdown from "../components/DownloadVex";
 import FeedbackReportCard from "../components/FeedbackReportCard";
 import { getReportSummaryForFeedback } from "../utils/feedbackReportSummary";
+import { getPullImageReference } from "../utils/containerImageReference";
 
 interface RepositoryReportPageErrorProps {
   title: string;
@@ -137,8 +138,9 @@ const RepositoryReportPage: React.FC = () => {
     );
   }
 
+  const pullableImageRef = getPullImageReference(image);
   const reportIdDisplay = vuln.vuln_id
-    ? `${vuln.vuln_id} | ${image?.name || ""} | ${image?.tag || ""}`
+    ? [vuln.vuln_id, pullableImageRef].filter(Boolean).join(" | ")
     : "";
   // Extract product name from metadata, fallback to productId
   const productName = report?.metadata?.product_id;
@@ -164,7 +166,7 @@ const RepositoryReportPage: React.FC = () => {
                     fontSize: "var(--pf-t--global--font--size--heading--h6)",
                   }}
                 >
-                  {cveId} | {image?.name || ""} | {image?.tag || ""}
+                  {[cveId, pullableImageRef].filter(Boolean).join(" | ")}
                 </span>
               </Title>
             </FlexItem>

--- a/src/main/webui/src/utils/containerImageReference.ts
+++ b/src/main/webui/src/utils/containerImageReference.ts
@@ -1,10 +1,10 @@
 import type { FullReportImage } from "../types/FullReport";
 
 /**
- * Builds a container image reference suitable for `podman pull <ref>` / `docker pull <ref>`.
- * Omits source-based reports (git URL in {@code name}) and HTTP(S) URLs that are not image registries.
+ * Builds a container image reference suitable for `podman pull`, `docker pull`, or any OCI-compatible pull.
+ * Returns {@code undefined} for source-based reports (git URL in {@code name}) and bare HTTP(S) URLs that are not registry references.
  */
-export function podmanPullImageReference(
+export function getPullImageReference(
   image: FullReportImage | undefined
 ): string | undefined {
   if (!image) {
@@ -26,30 +26,4 @@ export function podmanPullImageReference(
     return `${name}@${tag}`;
   }
   return `${name}:${tag}`;
-}
-
-/**
- * Best-effort HTTPS URL for opening a container image reference in the browser
- * (registry UI or root path); link text remains the pull reference from {@link podmanPullImageReference}.
- */
-export function containerImageBrowseUrl(pullReference: string): string {
-  const t = pullReference.trim();
-  if (/^https?:\/\//i.test(t)) {
-    return t;
-  }
-  let base = t.includes("@") ? (t.split("@")[0] ?? t) : t;
-  const colonIdx = base.lastIndexOf(":");
-  if (colonIdx > 0) {
-    const after = base.slice(colonIdx + 1);
-    if (/^[A-Za-z0-9._-]+$/.test(after) && !after.includes("/")) {
-      base = base.slice(0, colonIdx);
-    }
-  }
-  if (base.startsWith("quay.io/")) {
-    return `https://quay.io/repository/${base.slice("quay.io/".length)}`;
-  }
-  if (!base.includes("/")) {
-    return `https://hub.docker.com/_/${encodeURIComponent(base)}`;
-  }
-  return `https://${base}`;
 }

--- a/src/main/webui/src/utils/containerImageReference.ts
+++ b/src/main/webui/src/utils/containerImageReference.ts
@@ -1,0 +1,55 @@
+import type { FullReportImage } from "../types/FullReport";
+
+/**
+ * Builds a container image reference suitable for `podman pull <ref>` / `docker pull <ref>`.
+ * Omits source-based reports (git URL in {@code name}) and HTTP(S) URLs that are not image registries.
+ */
+export function podmanPullImageReference(
+  image: FullReportImage | undefined
+): string | undefined {
+  if (!image) {
+    return undefined;
+  }
+  const name = image.name?.trim();
+  if (!name) {
+    return undefined;
+  }
+  /** Source-based reports store a git URL in {@code name}; not a container image reference. */
+  if (image.analysis_type === "source" || /^https?:\/\//i.test(name)) {
+    return undefined;
+  }
+  const tag = image.tag?.trim() ?? "";
+  if (!tag) {
+    return name;
+  }
+  if (/^sha256:[a-fA-F0-9]+$/i.test(tag)) {
+    return `${name}@${tag}`;
+  }
+  return `${name}:${tag}`;
+}
+
+/**
+ * Best-effort HTTPS URL for opening a container image reference in the browser
+ * (registry UI or root path); link text remains the pull reference from {@link podmanPullImageReference}.
+ */
+export function containerImageBrowseUrl(pullReference: string): string {
+  const t = pullReference.trim();
+  if (/^https?:\/\//i.test(t)) {
+    return t;
+  }
+  let base = t.includes("@") ? (t.split("@")[0] ?? t) : t;
+  const colonIdx = base.lastIndexOf(":");
+  if (colonIdx > 0) {
+    const after = base.slice(colonIdx + 1);
+    if (/^[A-Za-z0-9._-]+$/.test(after) && !after.includes("/")) {
+      base = base.slice(0, colonIdx);
+    }
+  }
+  if (base.startsWith("quay.io/")) {
+    return `https://quay.io/repository/${base.slice("quay.io/".length)}`;
+  }
+  if (!base.includes("/")) {
+    return `https://hub.docker.com/_/${encodeURIComponent(base)}`;
+  }
+  return `https://${base}`;
+}

--- a/src/main/webui/src/utils/feedbackReportSummary.ts
+++ b/src/main/webui/src/utils/feedbackReportSummary.ts
@@ -6,6 +6,7 @@
  */
 
 import type { FullReport } from "../types/FullReport";
+import { getPullImageReference } from "./containerImageReference";
 
 export function getReportSummaryForFeedback(report: FullReport): string {
   if (!report?.input) {
@@ -26,11 +27,9 @@ export function getReportSummaryForFeedback(report: FullReport): string {
 
   lines.push(`Name: ${name}`);
   lines.push("");
-  if (image?.name) {
-    lines.push(`Image: ${image.name}`);
-    if (image.tag) {
-      lines.push(`Tag: ${image.tag}`);
-    }
+  const pullable = getPullImageReference(image);
+  if (pullable) {
+    lines.push(`Image: ${pullable}`);
     lines.push("");
   }
   lines.push(`Repository: ${repoSource?.git_repo ?? ""}`);

--- a/src/test/resources/devservices/reports/test-failed-single-repo-report.json
+++ b/src/test/resources/devservices/reports/test-failed-single-repo-report.json
@@ -9,7 +9,7 @@
   "input": {
     "scan": {
       "id": "failed-single-repo-scan-1",
-      "type": null,
+      "type": "source",
       "started_at": "2026-04-02T11:00:00.000000",
       "completed_at": "2026-04-02T11:10:00.000000",
       "vulns": [
@@ -30,8 +30,9 @@
       ]
     },
     "image": {
-      "name": "failed-single-repo-image",
-      "tag": "dev",
+      "analysis_type": "source",
+      "name": "https://github.com/example/failed-single-repo",
+      "tag": "develop",
       "source_info": [
         {
           "type": "code",

--- a/src/test/resources/devservices/reports/test-single-repo-1.json
+++ b/src/test/resources/devservices/reports/test-single-repo-1.json
@@ -5,7 +5,7 @@
   "input": {
     "scan": {
       "id": "test-single-repo-1",
-      "type": null,
+      "type": "source",
       "started_at": "2025-01-15T10:00:00.000000",
       "completed_at": "2026-03-08T10:00:00.000000",
       "vulns": [
@@ -26,8 +26,9 @@
       ]
     },
     "image": {
-      "name": "single-repo-image",
-      "tag": "v1.0.0",
+      "analysis_type": "source",
+      "name": "https://github.com/example/single-repo-no-product",
+      "tag": "abc1234",
       "source_info": [
         {
           "type": "code",

--- a/src/test/resources/devservices/reports/test-single-repo-2.json
+++ b/src/test/resources/devservices/reports/test-single-repo-2.json
@@ -5,7 +5,7 @@
   "input": {
     "scan": {
       "id": "test-single-repo-2",
-      "type": null,
+      "type": "source",
       "started_at": "2026-03-07T10:00:00.000000",
       "completed_at": "2026-03-08T10:00:00.000000",
       "vulns": [
@@ -26,8 +26,9 @@
       ]
     },
     "image": {
-      "name": "single-repo-image-2",
-      "tag": "v1.0.0",
+      "analysis_type": "source",
+      "name": "https://github.com/example/single-repo-app-b",
+      "tag": "def5678",
       "source_info": [
         {
           "type": "code",

--- a/src/test/resources/devservices/reports/test-single-repo-3.json
+++ b/src/test/resources/devservices/reports/test-single-repo-3.json
@@ -5,7 +5,7 @@
   "input": {
     "scan": {
       "id": "test-single-repo-3",
-      "type": null,
+      "type": "source",
       "started_at": "2026-03-07T11:00:00.000000",
       "completed_at": "2026-03-08T12:00:00.000000",
       "vulns": [
@@ -26,8 +26,9 @@
       ]
     },
     "image": {
-      "name": "single-repo-image-3",
-      "tag": "v2.0.0",
+      "analysis_type": "source",
+      "name": "https://github.com/example/single-repo-lib-c",
+      "tag": "main",
       "source_info": [
         {
           "type": "code",

--- a/src/test/resources/devservices/reports/test-single-repo-4.json
+++ b/src/test/resources/devservices/reports/test-single-repo-4.json
@@ -5,7 +5,7 @@
   "input": {
     "scan": {
       "id": "test-single-repo-4",
-      "type": null,
+      "type": "source",
       "started_at": "2026-03-06T14:00:00.000000",
       "completed_at": "2026-03-08T14:30:00.000000",
       "vulns": [
@@ -26,8 +26,9 @@
       ]
     },
     "image": {
-      "name": "single-repo-image-4",
-      "tag": "v1.2.0",
+      "analysis_type": "source",
+      "name": "https://github.com/example/single-repo-service-d",
+      "tag": "release-1.x",
       "source_info": [
         {
           "type": "code",

--- a/src/test/resources/devservices/reports/test-single-repo-5.json
+++ b/src/test/resources/devservices/reports/test-single-repo-5.json
@@ -5,7 +5,7 @@
   "input": {
     "scan": {
       "id": "test-single-repo-5",
-      "type": null,
+      "type": "source",
       "started_at": "2026-03-08T08:00:00.000000",
       "completed_at": "2026-03-08T09:00:00.000000",
       "vulns": [
@@ -26,8 +26,9 @@
       ]
     },
     "image": {
-      "name": "single-repo-image-5",
-      "tag": "v3.0.0",
+      "analysis_type": "source",
+      "name": "https://github.com/example/single-repo-cli-e",
+      "tag": "abc1234",
       "source_info": [
         {
           "type": "code",

--- a/src/test/resources/devservices/reports/test-single-repo-6.json
+++ b/src/test/resources/devservices/reports/test-single-repo-6.json
@@ -5,7 +5,7 @@
   "input": {
     "scan": {
       "id": "test-single-repo-6",
-      "type": null,
+      "type": "source",
       "started_at": "2026-03-08T15:00:00.000000",
       "completed_at": "2026-03-08T16:00:00.000000",
       "vulns": [
@@ -26,8 +26,9 @@
       ]
     },
     "image": {
-      "name": "single-repo-image-6",
-      "tag": "v0.9.0",
+      "analysis_type": "source",
+      "name": "https://github.com/example/single-repo-sdk-f",
+      "tag": "feature-branch",
       "source_info": [
         {
           "type": "code",

--- a/src/test/resources/devservices/reports/test-single-repo-7.json
+++ b/src/test/resources/devservices/reports/test-single-repo-7.json
@@ -5,7 +5,7 @@
   "input": {
     "scan": {
       "id": "test-single-repo-7",
-      "type": null,
+      "type": "source",
       "started_at": "2026-03-08T10:00:00.000000",
       "completed_at": "2026-03-08T11:00:00.000000",
       "vulns": [
@@ -26,8 +26,9 @@
       ]
     },
     "image": {
-      "name": "single-repo-image-7",
-      "tag": "v1.1.0",
+      "analysis_type": "source",
+      "name": "https://github.com/example/single-repo-api-g",
+      "tag": "develop",
       "source_info": [
         {
           "type": "code",


### PR DESCRIPTION
### Changes: 
- Change the field from `commit ID` to `image URL` on the repository report page.

- Implement a function that builds a container image reference suitable for` podman pull <ref> `/ `docker pull <ref>`.

- Append the commit to the repository URL, so clicking on it takes you directly to the code snapshot.