### PR TITLE
Add apache 2.0 licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -201,33 +201,26 @@
    limitations under the License.
 
 ### THIRD-PARTY LICENSES
-- nginx		2-clause BSD license
-- aiohttp-client-cache		Apache License 2.0
-- aiohttp		Apache License 2.0
-- aioresponses		MIT License
-- beautifulsoup4		MIT License
-- esprima-python		BSD 2-Clause License
-- faiss		MIT License
-- git-lfs		MIT License
-- gitpython		BSD 3-Clause License
-- json5		MIT License
-- openai		MIT License
-- packaging		Apache License 2.0 and BSD 2-Clause License
-- pydantic		MIT License
-- sentence-transformers		Apache License 2.0
-- tenacity		Apache License 2.0
-- tiktoken		MIT License
-- tini		MIT License
-- transformers		Apache License 2.0
-- uvloop		Apache License 2.0 and MIT License
-- google-search-results		MIT License
-- langchain		MIT License
-- langchain-community		MIT License
-- langchain-core		MIT License
-- nemollm		Apache License 2.0
-- pydpkg		MIT License
-- rank_bm25		MIT License
-- tree-sitter		MIT License
-- tree-sitter-languages		MIT License
-- univers		Apache License 2.0
-- wget		GNU General Public License (GPL) version 3
+
+#### Java / JVM Dependencies
+- Quarkus                                    Apache License 2.0
+- Quarkus Quinoa                             Apache License 2.0
+- Jackson (Databind, Core, Annotations)      Apache License 2.0
+- MongoDB Java Driver                        Apache License 2.0
+- Eclipse Vert.x                             Apache License 2.0
+- SmallRye Health                            Apache License 2.0
+- SmallRye OpenAPI                           Apache License 2.0
+- SmallRye Context Propagation               Apache License 2.0
+- Micrometer                                 Apache License 2.0
+- OpenTelemetry Java                         Apache License 2.0
+- Hibernate Validator                        Apache License 2.0
+- JBoss Log Manager                          Apache License 2.0
+
+#### Frontend Dependencies (production bundle)
+- React                                      MIT License
+- PatternFly React (core, charts,
+  component-groups, icons, table)            MIT License
+- react-router / react-router-dom            MIT License
+- lodash                                     MIT License
+- react-markdown                             MIT License
+- victory                                    MIT License

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,233 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf with, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, you may act only
+      on your own behalf and on your sole responsibility, not on behalf
+      of any other Contributor, and only if you agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+### THIRD-PARTY LICENSES
+- nginx		2-clause BSD license
+- aiohttp-client-cache		Apache License 2.0
+- aiohttp		Apache License 2.0
+- aioresponses		MIT License
+- beautifulsoup4		MIT License
+- esprima-python		BSD 2-Clause License
+- faiss		MIT License
+- git-lfs		MIT License
+- gitpython		BSD 3-Clause License
+- json5		MIT License
+- openai		MIT License
+- packaging		Apache License 2.0 and BSD 2-Clause License
+- pydantic		MIT License
+- sentence-transformers		Apache License 2.0
+- tenacity		Apache License 2.0
+- tiktoken		MIT License
+- tini		MIT License
+- transformers		Apache License 2.0
+- uvloop		Apache License 2.0 and MIT License
+- google-search-results		MIT License
+- langchain		MIT License
+- langchain-community		MIT License
+- langchain-core		MIT License
+- nemollm		Apache License 2.0
+- pydpkg		MIT License
+- rank_bm25		MIT License
+- tree-sitter		MIT License
+- tree-sitter-languages		MIT License
+- univers		Apache License 2.0
+- wget		GNU General Public License (GPL) version 3

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Red Hat Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Red Hat Exploit Intelligence- client
 
 This project is a Quarkus + React web application implemented to interact with ExploitIQ service

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,3 +1,17 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Authentication
 
 This guide covers authentication configuration for ExploitIQ Client, including OpenShift OAuth, external identity providers, and development setups.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,3 +1,17 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Configuration
 
 ## Authentication

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,17 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Development
 
 ## Configuration

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/client/ComponentSyncerService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/client/ComponentSyncerService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.client;
 
 

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/client/FeedbackApi.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/client/FeedbackApi.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.client;
 
 import com.redhat.ecosystemappeng.morpheus.model.FeedbackDto;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/client/GitHubService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/client/GitHubService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.client;
 
 import java.util.Map;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/client/MorpheusService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/client/MorpheusService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.client;
 
 

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/config/AppConfig.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/config/AppConfig.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.config;
 
 import java.util.List;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/dev/DatabaseInit.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/dev/DatabaseInit.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.dev;
 
 import java.io.File;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/exception/CveIdValidationException.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/exception/CveIdValidationException.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.exception;
 
 /**

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/exception/ForbiddenExceptionMapper.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/exception/ForbiddenExceptionMapper.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.exception;
 
 import io.quarkus.security.ForbiddenException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/exception/SbomValidationException.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/exception/SbomValidationException.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.exception;
 
 /**

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/exception/SyftExecutionException.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/exception/SyftExecutionException.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.exception;
 
 /**

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/exception/ValidationException.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/exception/ValidationException.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.exception;
 
 import java.util.Map;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/health/ComponentSyncerHealthCheck.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/health/ComponentSyncerHealthCheck.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.health;
 
 import io.smallrye.health.api.HealthGroup;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/health/EngineHealthCheck.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/health/EngineHealthCheck.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.health;
 
 import io.vertx.mutiny.ext.web.client.WebClient;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/health/HealthUtils.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/health/HealthUtils.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.health;
 
 import java.io.IOException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/metrics/AgentMorpheusBusinessInsights.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/metrics/AgentMorpheusBusinessInsights.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.metrics;
 
 

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/metrics/AgentMorpheusMetrics.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/metrics/AgentMorpheusMetrics.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.metrics;
 
 import io.micrometer.core.instrument.Counter;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/CredentialData.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/CredentialData.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import jakarta.ws.rs.BadRequestException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/CredentialType.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/CredentialType.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ErrorResponse.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ErrorResponse.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/FailedComponent.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/FailedComponent.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/FeedbackDto.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/FeedbackDto.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/InlineCredential.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/InlineCredential.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/Justification.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/Justification.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/MarkReportFailedRequest.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/MarkReportFailedRequest.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/OverviewMetricsDTO.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/OverviewMetricsDTO.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/PaginatedResult.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/PaginatedResult.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import java.util.stream.Stream;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/Pagination.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/Pagination.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ParsedCycloneDx.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ParsedCycloneDx.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/PreProcessingRequest.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/PreProcessingRequest.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import java.util.List;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/Product.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/Product.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ProductReportsSummary.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ProductReportsSummary.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import java.util.Map;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ProductSummary.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ProductSummary.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/Report.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/Report.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import java.util.Map;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ReportData.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ReportData.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ReportReceivedEvent.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ReportReceivedEvent.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ReportRequest.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ReportRequest.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import java.util.Collection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ReportRequestId.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ReportRequestId.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ReportWithStatus.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ReportWithStatus.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/SortField.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/SortField.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import java.util.List;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/SortType.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/SortType.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/UserComments.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/UserComments.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ValidationErrorResponse.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/ValidationErrorResponse.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import java.util.Map;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/Views.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/Views.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 public class Views {

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/VulnResult.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/VulnResult.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/Batch.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/Batch.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.audit;
 
 import com.fasterxml.jackson.annotation.JsonFormat;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/BatchType.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/BatchType.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.audit;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/Eval.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/Eval.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.audit;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/Job.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/Job.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.audit;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/LLMStage.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/LLMStage.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.audit;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/MetricName.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/MetricName.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.audit;
 
 public enum MetricName {

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/Trace.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/audit/Trace.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.audit;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/Image.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/Image.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.morpheus;
 
 import java.util.Collection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/ReportInput.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/ReportInput.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.morpheus;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/SbomInfoType.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/SbomInfoType.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.morpheus;
 
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/Scan.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/Scan.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.morpheus;
 
 import java.util.Collection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/SourceInfo.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/SourceInfo.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.morpheus;
 
 import java.util.Collection;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/VulnId.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/model/morpheus/VulnId.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.model.morpheus;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/AuditRepository.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/AuditRepository.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.repository;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/BatchRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/BatchRepositoryService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.repository;
 
 import com.mongodb.client.MongoClient;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/EvalRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/EvalRepositoryService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/JobRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/JobRepositoryService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/ProductRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/ProductRepositoryService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.repository;
 
 import java.time.Instant;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/ReportRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/ReportRepositoryService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.repository;
 
 import java.time.Instant;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/TraceRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/repository/TraceRepositoryService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/CredentialsEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/CredentialsEndpoint.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest;
 
 import com.redhat.ecosystemappeng.morpheus.service.UserService;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/FeedbackResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/FeedbackResource.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest;
 
 import com.redhat.ecosystemappeng.morpheus.model.FeedbackDto;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/ManagementProxyFilter.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/ManagementProxyFilter.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest;
 
 import io.smallrye.mutiny.Uni;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/NotificationSocket.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/NotificationSocket.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest;
 
 import org.jboss.logging.Logger;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/OverviewMetricsResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/OverviewMetricsResource.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest;
 
 import com.redhat.ecosystemappeng.morpheus.model.OverviewMetricsDTO;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/PreProcessingEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/PreProcessingEndpoint.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/ProductEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/ProductEndpoint.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest;
 
 import java.io.IOException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/ReportEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/ReportEndpoint.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest;
 
 import java.util.List;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/TokenResource.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest;
 
 import jakarta.annotation.security.PermitAll;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/audit/BaseAuditEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/audit/BaseAuditEndpoint.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest.audit;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/audit/BatchEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/audit/BatchEndpoint.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest.audit;
 
 import com.redhat.ecosystemappeng.morpheus.model.audit.Batch;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/audit/EvalEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/audit/EvalEndpoint.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest.audit;
 
 import com.redhat.ecosystemappeng.morpheus.model.audit.Eval;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/audit/JobEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/audit/JobEndpoint.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest.audit;
 
 import com.redhat.ecosystemappeng.morpheus.model.*;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/audit/TraceEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/rest/audit/TraceEndpoint.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.rest.audit;
 
 import com.redhat.ecosystemappeng.morpheus.model.audit.Trace;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/security/RoleMappingAugmentor.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/security/RoleMappingAugmentor.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.security;
 
 import io.quarkus.runtime.LaunchMode;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ComponentProcessingService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ComponentProcessingService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import java.util.ArrayList;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/CredentialProcessingService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/CredentialProcessingService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import java.util.UUID;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/CredentialStorageException.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/CredentialStorageException.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 /**

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/CredentialStoreService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/CredentialStoreService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/CycloneDxParsingService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/CycloneDxParsingService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import java.io.IOException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/FeedbackService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/FeedbackService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import com.redhat.ecosystemappeng.morpheus.client.FeedbackApi;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/GenerateSbomService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/GenerateSbomService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import java.io.BufferedReader;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/OverviewMetricsService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/OverviewMetricsService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import com.redhat.ecosystemappeng.morpheus.model.OverviewMetricsDTO;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/PreProcessingService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/PreProcessingService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import java.io.IOException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ProductService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ProductService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import java.util.List;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ReportService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import java.io.FileInputStream;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/RepositoryConstants.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/RepositoryConstants.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 public interface RepositoryConstants {

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/RequestQueueExceededException.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/RequestQueueExceededException.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 public class RequestQueueExceededException extends RuntimeException {

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/RequestQueueService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/RequestQueueService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import java.time.Duration;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/SbomReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/SbomReportService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import java.io.IOException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/SpdxParsingService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/SpdxParsingService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import java.util.ArrayList;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/UserService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/UserService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import io.quarkus.arc.properties.IfBuildProperty;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/UtilitiesService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/UtilitiesService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service;
 
 import jakarta.ws.rs.core.SecurityContext;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/audit/AuditService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/audit/AuditService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service.audit;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/audit/BatchService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/audit/BatchService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service.audit;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/audit/EvalService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/audit/EvalService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service.audit;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/audit/JobService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/audit/JobService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service.audit;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/audit/TraceService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/audit/TraceService.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service.audit;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/jwt/JkwsRequestFilter.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/jwt/JkwsRequestFilter.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.service.jwt;
 
 import jakarta.annotation.PostConstruct;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/tracing/TextMapPropagatorImpl.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/tracing/TextMapPropagatorImpl.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.tracing;
 
 import io.opentelemetry.context.Context;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/tracing/TraceToMdc.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/tracing/TraceToMdc.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.tracing;
 
 

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/tracing/TraceToMdcInterceptor.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/tracing/TraceToMdcInterceptor.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.tracing;
 
 import io.opentelemetry.context.Context;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/tracing/TracingFieldsCustomizer.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/tracing/TracingFieldsCustomizer.java
@@ -1,3 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.ecosystemappeng.morpheus.tracing;
 
 import io.opentelemetry.context.ContextKey;

--- a/src/main/resources/META-INF/resources/error/403.html
+++ b/src/main/resources/META-INF/resources/error/403.html
@@ -1,4 +1,17 @@
 <!DOCTYPE html>
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <html lang="en" class="pf-v6-u-h-100">
 
 <head>

--- a/src/main/webui/README-API-TYPES.md
+++ b/src/main/webui/README-API-TYPES.md
@@ -1,3 +1,17 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Generating TypeScript Types from OpenAPI
 
 This project uses [openapi-typescript-codegen](https://github.com/ferdikoomen/openapi-typescript-codegen) to generate TypeScript client code from the OpenAPI specification.

--- a/src/main/webui/index.html
+++ b/src/main/webui/index.html
@@ -1,4 +1,17 @@
 <!doctype html>
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/src/main/webui/src/App.tsx
+++ b/src/main/webui/src/App.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router";
 import AppLayout from "./components/AppLayout";

--- a/src/main/webui/src/components/AppLayout.tsx
+++ b/src/main/webui/src/components/AppLayout.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React, { useState } from 'react';
 import { Outlet } from 'react-router';
 import { Page, PageSidebar } from '@patternfly/react-core';

--- a/src/main/webui/src/components/ChecklistCard.tsx
+++ b/src/main/webui/src/components/ChecklistCard.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useEffect, useState } from "react";
 import {
   Card,

--- a/src/main/webui/src/components/CveDescriptionCard.tsx
+++ b/src/main/webui/src/components/CveDescriptionCard.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import ReactMarkdown from "react-markdown";
 import { Content, EmptyState, EmptyStateBody } from "@patternfly/react-core";
 import { SearchIcon } from "@patternfly/react-icons";

--- a/src/main/webui/src/components/CveDetailsPageSkeleton.tsx
+++ b/src/main/webui/src/components/CveDetailsPageSkeleton.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React from "react";
 import {
   PageSection,

--- a/src/main/webui/src/components/CveMetadataCard.tsx
+++ b/src/main/webui/src/components/CveMetadataCard.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {
   DescriptionList,
   DescriptionListGroup,

--- a/src/main/webui/src/components/CveReferencesCard.tsx
+++ b/src/main/webui/src/components/CveReferencesCard.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {
   List,
   ListItem,

--- a/src/main/webui/src/components/CveStatus.tsx
+++ b/src/main/webui/src/components/CveStatus.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Label } from "@patternfly/react-core";
 import { apiToColor, apiToDisplay } from "../utils/justificationStatus";
 

--- a/src/main/webui/src/components/CveVulnerablePackagesCard.tsx
+++ b/src/main/webui/src/components/CveVulnerablePackagesCard.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {
   List,
   ListItem,

--- a/src/main/webui/src/components/CvssBanner.tsx
+++ b/src/main/webui/src/components/CvssBanner.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Flex, FlexItem } from "@patternfly/react-core";
 import {
   SeverityCriticalIcon,

--- a/src/main/webui/src/components/DetailsCard.tsx
+++ b/src/main/webui/src/components/DetailsCard.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {
   Card,
   CardTitle,

--- a/src/main/webui/src/components/DonutChartWrapper.tsx
+++ b/src/main/webui/src/components/DonutChartWrapper.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { ChartDonut, ChartLegend, ChartLabel } from '@patternfly/react-charts/victory';
 
 interface DonutChartWrapperProps {

--- a/src/main/webui/src/components/DownloadVex.tsx
+++ b/src/main/webui/src/components/DownloadVex.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useState } from "react";
 import {
   Dropdown,

--- a/src/main/webui/src/components/FeedbackReportCard.tsx
+++ b/src/main/webui/src/components/FeedbackReportCard.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useState, useCallback } from "react";
 import type { CSSProperties } from "react";
 import {

--- a/src/main/webui/src/components/Filtering.tsx
+++ b/src/main/webui/src/components/Filtering.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useState, useEffect, useRef } from "react";
 import {
   Menu,

--- a/src/main/webui/src/components/Finding.tsx
+++ b/src/main/webui/src/components/Finding.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Label, LabelProps } from "@patternfly/react-core";
 import type { Finding as FindingType } from "../utils/findingDisplay";
 import { ExclamationCircleIcon, InProgressIcon } from "@patternfly/react-icons";

--- a/src/main/webui/src/components/FormattedTimestamp.tsx
+++ b/src/main/webui/src/components/FormattedTimestamp.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Timestamp } from "@patternfly/react-core";
 
 interface FormattedTimestampProps {

--- a/src/main/webui/src/components/GetStartedCard.tsx
+++ b/src/main/webui/src/components/GetStartedCard.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { FunctionComponent, useState } from "react";
 import MultiContentCard from "@patternfly/react-component-groups/dist/dynamic/MultiContentCard";
 import {

--- a/src/main/webui/src/components/IntelReliabilityScore.tsx
+++ b/src/main/webui/src/components/IntelReliabilityScore.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Progress, ProgressSize } from "@patternfly/react-core";
 import NotAvailable from "./NotAvailable";
 

--- a/src/main/webui/src/components/MetadataDisplay.tsx
+++ b/src/main/webui/src/components/MetadataDisplay.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Label, LabelGroup } from "@patternfly/react-core";
 import NotAvailable from "./NotAvailable";
 

--- a/src/main/webui/src/components/MetricsCard.tsx
+++ b/src/main/webui/src/components/MetricsCard.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React from "react";
 import {
   Card,

--- a/src/main/webui/src/components/Navigation.tsx
+++ b/src/main/webui/src/components/Navigation.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React from "react";
 import { Nav, NavList, NavItem, PageSidebarBody } from "@patternfly/react-core";
 import { useNavigate, useLocation } from "react-router";

--- a/src/main/webui/src/components/NotAvailable.tsx
+++ b/src/main/webui/src/components/NotAvailable.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 const NotAvailable: React.FC = () => {
   return <span>---</span>;
 };

--- a/src/main/webui/src/components/PageHeader.tsx
+++ b/src/main/webui/src/components/PageHeader.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Page header (masthead) component with branding and user toolbar
  * Based on reference implementation pattern

--- a/src/main/webui/src/components/ProductRedirect.tsx
+++ b/src/main/webui/src/components/ProductRedirect.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useEffect } from "react";
 import { useParams, useNavigate } from "react-router";
 

--- a/src/main/webui/src/components/ReportAdditionalDetails.tsx
+++ b/src/main/webui/src/components/ReportAdditionalDetails.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {
   Card,
   CardTitle,

--- a/src/main/webui/src/components/ReportComponentStatesPieChart.tsx
+++ b/src/main/webui/src/components/ReportComponentStatesPieChart.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useMemo } from "react";
 import {
   Card,

--- a/src/main/webui/src/components/ReportCveStatusPieChart.tsx
+++ b/src/main/webui/src/components/ReportCveStatusPieChart.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useMemo } from "react";
 import {
   Card,

--- a/src/main/webui/src/components/ReportDetails.tsx
+++ b/src/main/webui/src/components/ReportDetails.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {
   Card,
   CardTitle,

--- a/src/main/webui/src/components/ReportPageSkeleton.tsx
+++ b/src/main/webui/src/components/ReportPageSkeleton.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {
   PageSection,
   Grid,

--- a/src/main/webui/src/components/ReportStatusLabel.tsx
+++ b/src/main/webui/src/components/ReportStatusLabel.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Label } from "@patternfly/react-core";
 import { CheckCircleIcon, SyncIcon } from "@patternfly/react-icons";
 import { FailedStatus } from "./Finding";

--- a/src/main/webui/src/components/ReportsPageContent.tsx
+++ b/src/main/webui/src/components/ReportsPageContent.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useLocation, useNavigate } from "react-router";
 import {
   PageSection,

--- a/src/main/webui/src/components/ReportsToolbar.tsx
+++ b/src/main/webui/src/components/ReportsToolbar.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React from "react";
 import {
   Toolbar,

--- a/src/main/webui/src/components/RepositoryAdditionalDetailsCard.tsx
+++ b/src/main/webui/src/components/RepositoryAdditionalDetailsCard.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useState } from "react";
 import {
   Card,

--- a/src/main/webui/src/components/RepositoryReportPageSkeleton.tsx
+++ b/src/main/webui/src/components/RepositoryReportPageSkeleton.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {
   Grid,
   GridItem,

--- a/src/main/webui/src/components/RepositoryReportsTable.tsx
+++ b/src/main/webui/src/components/RepositoryReportsTable.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import type { Report } from "../generated-client/models/Report";
 import type { ProductSummary } from "../generated-client/models/ProductSummary";
 import RepositoryReportsTableContent from "./RepositoryReportsTableContent";

--- a/src/main/webui/src/components/RepositoryReportsTableContent.tsx
+++ b/src/main/webui/src/components/RepositoryReportsTableContent.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useMemo } from "react";
 import { Link } from "react-router";
 import {

--- a/src/main/webui/src/components/RepositoryTableToolbar.tsx
+++ b/src/main/webui/src/components/RepositoryTableToolbar.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useState } from "react";
 import {
   Toolbar,

--- a/src/main/webui/src/components/RequestAnalysisModal.tsx
+++ b/src/main/webui/src/components/RequestAnalysisModal.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React, { useState, useRef } from "react";
 import {
   Modal,

--- a/src/main/webui/src/components/SbomsTable.tsx
+++ b/src/main/webui/src/components/SbomsTable.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useState } from "react";
 import { Link } from "react-router";
 import {

--- a/src/main/webui/src/components/SingleRepositoriesTable.tsx
+++ b/src/main/webui/src/components/SingleRepositoriesTable.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import type { Report } from "../generated-client/models/Report";
 import RepositoryReportsTableContent from "./RepositoryReportsTableContent";
 import { useTableParams } from "../hooks/useTableParams";

--- a/src/main/webui/src/components/SkeletonCard.tsx
+++ b/src/main/webui/src/components/SkeletonCard.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Card, CardBody, Skeleton, Stack, StackItem } from "@patternfly/react-core";
 
 interface SkeletonCardProps {

--- a/src/main/webui/src/components/TableEmptyState.tsx
+++ b/src/main/webui/src/components/TableEmptyState.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Table, Thead, Tr, Th, Tbody, Td } from "@patternfly/react-table";
 import {
   Bullseye,

--- a/src/main/webui/src/components/TableErrorState.tsx
+++ b/src/main/webui/src/components/TableErrorState.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Table, Thead, Tr, Th, Tbody, Td } from "@patternfly/react-table";
 import {
   Bullseye,

--- a/src/main/webui/src/components/UserAvatarDropdown.tsx
+++ b/src/main/webui/src/components/UserAvatarDropdown.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * User avatar dropdown component for the page header
  * Displays authenticated user information and provides logout functionality

--- a/src/main/webui/src/constants/pagination.ts
+++ b/src/main/webui/src/constants/pagination.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { PerPageOptions } from "@patternfly/react-core";
 
 /** Shared per-page options for table pagination (reports table and repository reports table). */

--- a/src/main/webui/src/hooks/repositoryReportsTableParams.ts
+++ b/src/main/webui/src/hooks/repositoryReportsTableParams.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Types and constants for repository reports table URL state.
  * Use with useTableParams; pass params.data to useRepositoryReports and params to toolbar/content.

--- a/src/main/webui/src/hooks/useApi.ts
+++ b/src/main/webui/src/hooks/useApi.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Generic React hook for API calls
  * Supports any promise (including CancelablePromise from generated client)

--- a/src/main/webui/src/hooks/useAuth.ts
+++ b/src/main/webui/src/hooks/useAuth.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Authentication hook for user information and logout
  * Integrates with Quarkus OIDC backend authentication

--- a/src/main/webui/src/hooks/useCveDetails.ts
+++ b/src/main/webui/src/hooks/useCveDetails.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useMemo } from "react";
 import { useApi } from "./useApi";
 import { getRepositoryReport } from "../utils/reportApi";

--- a/src/main/webui/src/hooks/useDocumentTitle.ts
+++ b/src/main/webui/src/hooks/useDocumentTitle.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useEffect } from "react";
 
 /**

--- a/src/main/webui/src/hooks/useExecuteApi.ts
+++ b/src/main/webui/src/hooks/useExecuteApi.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Hook for on-demand API calls that require explicit execution
  * Does not fetch immediately - requires manual trigger via execute()

--- a/src/main/webui/src/hooks/usePaginatedApi.ts
+++ b/src/main/webui/src/hooks/usePaginatedApi.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Hook for paginated API calls that captures response headers
  * Returns pagination metadata from X-Total-Elements and X-Total-Pages headers

--- a/src/main/webui/src/hooks/useReport.ts
+++ b/src/main/webui/src/hooks/useReport.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useApi } from "./useApi";
 import type { ProductSummary } from "../generated-client/models/ProductSummary";
 import { POLL_INTERVAL_MS, shouldContinuePollingByProductState } from "../utils/polling";

--- a/src/main/webui/src/hooks/useReportsTableData.ts
+++ b/src/main/webui/src/hooks/useReportsTableData.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useMemo } from "react";
 import { isEqual } from "lodash";
 import { usePaginatedApi } from "./usePaginatedApi";

--- a/src/main/webui/src/hooks/useRepositoryReport.ts
+++ b/src/main/webui/src/hooks/useRepositoryReport.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useApi } from "./useApi";
 import { getRepositoryReport } from "../utils/reportApi";
 import { POLL_INTERVAL_MS } from "../utils/polling";

--- a/src/main/webui/src/hooks/useRepositoryReports.ts
+++ b/src/main/webui/src/hooks/useRepositoryReports.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Hook for fetching repository reports with pagination, filtering, and auto-refresh
  */

--- a/src/main/webui/src/hooks/useTableParams.ts
+++ b/src/main/webui/src/hooks/useTableParams.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Generic hook that reads and writes table state (sort, filter, pagination) from the URL.
  * Does not apply defaults; the caller/table applies defaults.

--- a/src/main/webui/src/hooks/useVulnComments.ts
+++ b/src/main/webui/src/hooks/useVulnComments.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Hook to fetch user comments for a vulnerability
  */

--- a/src/main/webui/src/main.tsx
+++ b/src/main/webui/src/main.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";

--- a/src/main/webui/src/pages/CveDetailsPage.tsx
+++ b/src/main/webui/src/pages/CveDetailsPage.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useMemo } from "react";
 import { useParams, Link } from "react-router";
 import {

--- a/src/main/webui/src/pages/ExcludedComponentsPage.tsx
+++ b/src/main/webui/src/pages/ExcludedComponentsPage.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useMemo } from "react";
 import { useParams, Link } from "react-router";
 import {

--- a/src/main/webui/src/pages/HomePage.tsx
+++ b/src/main/webui/src/pages/HomePage.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React, { useState, useEffect } from "react";
 import {
   PageSection,

--- a/src/main/webui/src/pages/ReportPage.tsx
+++ b/src/main/webui/src/pages/ReportPage.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useMemo } from "react";
 import { useParams, Link } from "react-router";
 import {

--- a/src/main/webui/src/pages/ReportsPage.tsx
+++ b/src/main/webui/src/pages/ReportsPage.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { PageSection, Title } from "@patternfly/react-core";
 import { useLocation } from "react-router";
 import ReportsPageContent from "../components/ReportsPageContent";

--- a/src/main/webui/src/pages/RepositoryReportPage.tsx
+++ b/src/main/webui/src/pages/RepositoryReportPage.tsx
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useMemo } from "react";
 import { useParams, Link } from "react-router";
 import {

--- a/src/main/webui/src/pages/pageTitles.ts
+++ b/src/main/webui/src/pages/pageTitles.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Central definitions for browser tab (document) titles.
  * Use {@link withAppTitle} so every tab includes the product name.

--- a/src/main/webui/src/types/FullReport.ts
+++ b/src/main/webui/src/types/FullReport.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * TypeScript type definitions for FullReport
  * These types provide detailed structure and autocomplete for the report data

--- a/src/main/webui/src/types/Intel.ts
+++ b/src/main/webui/src/types/Intel.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * TypeScript type definitions for Intel structure in FullReport
  * This provides type safety for the info.intel array structure

--- a/src/main/webui/src/utils/containerImageReference.ts
+++ b/src/main/webui/src/utils/containerImageReference.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import type { FullReportImage } from "../types/FullReport";
 
 /**

--- a/src/main/webui/src/utils/errorHandling.ts
+++ b/src/main/webui/src/utils/errorHandling.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Error handling and loading state management utilities
  */

--- a/src/main/webui/src/utils/feedbackReportSummary.ts
+++ b/src/main/webui/src/utils/feedbackReportSummary.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Builds a plain-text summary of a report for use as AI response context in feedback.
  * Matches the format used by the legacy Report page (getReportSummary) so the backend

--- a/src/main/webui/src/utils/findingDisplay.ts
+++ b/src/main/webui/src/utils/findingDisplay.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { apiToFindingType } from "./justificationStatus";
 
 /**

--- a/src/main/webui/src/utils/formatting.ts
+++ b/src/main/webui/src/utils/formatting.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export const toTitleCase = (str: string): string => {
   return str.charAt(0).toUpperCase() + str.slice(1);
 };

--- a/src/main/webui/src/utils/justificationStatus.ts
+++ b/src/main/webui/src/utils/justificationStatus.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Shared mapping between ExploitIQ/justification API values (TRUE, FALSE, UNKNOWN)
  * and display labels (Vulnerable, Not Vulnerable, Uncertain).

--- a/src/main/webui/src/utils/polling.ts
+++ b/src/main/webui/src/utils/polling.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Shared constants and utilities for polling/auto-refresh functionality
  */

--- a/src/main/webui/src/utils/reportApi.ts
+++ b/src/main/webui/src/utils/reportApi.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * Typed wrapper functions for report API endpoints
  * These provide proper TypeScript types even when the OpenAPI spec

--- a/src/main/webui/src/utils/repositoriesAnalyzed.ts
+++ b/src/main/webui/src/utils/repositoriesAnalyzed.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import type { ProductSummary } from "../generated-client/models/ProductSummary";
 
 /**

--- a/src/main/webui/src/vite-env.d.ts
+++ b/src/main/webui/src/vite-env.d.ts
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {


### PR DESCRIPTION
Add LICENSE file, update readmes
Add Apache 2.0 licenses to all core Java, TypeScript/TSX, and HTML files.
Excluded are mocks, tests, build/ci, and deployment config files.