### PR TITLE
fix: full-width reports tabs and table

### DIFF
--- a/src/main/webui/src/components/ReportsPageContent.tsx
+++ b/src/main/webui/src/components/ReportsPageContent.tsx
@@ -41,11 +41,7 @@ const ReportsPageContent: React.FC = () => {
 
   return (
     <>
-      <PageSection
-        type="tabs"
-        isWidthLimited
-        aria-label="Reports navigation tabs"
-      >
+      <PageSection type="tabs" aria-label="Reports navigation tabs">
         <Tabs
           activeKey={activeTabKey}
           onSelect={handleTabClick}
@@ -64,7 +60,7 @@ const ReportsPageContent: React.FC = () => {
           />
         </Tabs>
       </PageSection>
-      <PageSection isWidthLimited aria-label="Reports content">
+      <PageSection aria-label="Reports content">
         <TabContent
           key={0}
           eventKey={0}


### PR DESCRIPTION
Change: Dropped ` isWidthLimited` from the tabs` PageSection` and from the `PageSection` that wraps `TabContent` / the tables in `ReportsPageContent.tsx`, so tabs and table follow the same full-width pattern as the Home content area. The Reports header in `ReportsPage.tsx` is unchanged and still limited, aligned with Home.

[JIRA](https://redhat.atlassian.net/issues?filter=-1&selectedIssue=APPENG-5180)
The bug:
<img width="1908" height="812" alt="image" src="https://github.com/user-attachments/assets/6883b68c-c295-494b-96ae-af6e3b0e7fff" />
