### PR TITLE
feat: add manifest and Programming language fields to request

### DIFF
--- a/openspec/specs/request-analysis-modal-single-repository/spec.md
+++ b/openspec/specs/request-analysis-modal-single-repository/spec.md
@@ -1,28 +1,39 @@
 # request-analysis-modal-single-repository Specification
 
 ## Purpose
-**Single Repository** mode: Source Repository (`http`|`https` only — no `git:` / `git@`), Commit ID, `ReportRequest` to `POST /api/v1/reports/new` with `analysisType:"source"` and optional `credential` when private repo ON. Text-field **keyboard Enter** behaves as **[Keyboard Enter on modal text fields](../request-analysis-modal/spec.md)**.
+**Single Repository** mode: Source Repository (`http`|`https` only — no `git:` / `git@`), Commit ID, **Private repository** (parent spec), collapsible **Advanced** (optional manifest path and programming language). Submit via `POST /api/v1/reports/new` with `analysisType:"source"`. Text-field **Enter** follows **[Keyboard Enter on modal text fields](../request-analysis-modal/spec.md)**.
 
 ## Requirements
 
-### Requirement: Single-repository submit and validation  
-When **Single Repository** is selected, submit SHALL require non-empty CVE, `sourceRepo`, and `commitId`. Repo URL validated HTTP/HTTPS; invalid URL ⇒ error under Source Repo field on **blur or submit**.
+### Requirement: Single-repository submit and validation
+Submit SHALL require non-empty CVE, `sourceRepo`, and `commitId`. Repo URL validated HTTP/HTTPS on **blur or submit**. Success **HTTP 202**: build `ReportRequest` (CVE in `vulnerabilities`, trimmed repo/commit, metadata, optional `credential`, optional trimmed `manifestPath`/`ecosystem` when supplied), POST with `submit: true`, navigate `/reports/component/:cveId/:reportId`. HTTP **400** maps `cveId`, `sourceRepo`, `commitId`, `manifestPath`, `ecosystem`, credential to field errors; modal stays open.
 
-Success **HTTP 202**: build `ReportRequest` (cve in `vulnerabilities`, trimmed repo/commit, metadata, credential if applicable), POST with `submit: true`, navigate `/reports/component/:cveId/:reportId` using response report id.
+#### Scenario: Happy path submits and navigates
+- **WHEN** valid CVE, HTTP(S) repo, Commit ID, and optional credential/Advanced fields empty or filled
+- **AND** user submits successfully
+- **THEN** POST `/reports/new` omitting blank Advanced values; on 202 navigate and close modal.
 
-HTTP 400 mapped to `cveId`, `sourceRepo`, `commitId`, credential ⇒ field errors (`FormHelperText` error); modal stays open.
+#### Scenario: Submit with empty repo or commit blocked
+- **WHEN** CVE, sourceRepo, or commitId is missing
+- **AND** user submits
+- **THEN** *Required* on each empty field; API not invoked.
 
-#### Scenario: Happy path submits and navigates  
-- **WHEN** valid CVE, valid HTTP(S) repo URL, Commit ID, optional credentials per switch  
-- **AND** user submits successfully  
-- **THEN** POST `/reports/new`; on 202 navigate component report route and close modal.
+#### Scenario: Bad repo URL blocked on blur or submit
+- **WHEN** Source Repo is filled but not valid HTTP/HTTPS (including disallowed `git:`/ssh-style patterns)
+- **AND** blur or submit runs validation
+- **THEN** descriptive URL error shown; submit blocked.
 
-#### Scenario: Submit with empty repo or commit blocked  
-- **WHEN** any of CVE/sourceRepo/commit missing  
-- **AND** user submits  
-- **THEN** *Required* on each empty applicable field; API not invoked.
+### Requirement: Advanced optional fields
+Single Repository SHALL show Source Repository and Commit ID, then **Private repository** controls, then **Advanced** (`ExpandableSection`, collapsed by default). Expanded **Advanced** SHALL show optional **Manifest path** (`TextInput`, path within the cloned repo) and **Programming language** (`FormSelect`: unset placeholder plus `go`, `python`, `javascript`, `java`, `c`). Neither Advanced field SHALL block submit when empty. Server errors for `ecosystem` SHALL show under the dropdown.
 
-#### Scenario: Bad repo URL blocked on blur or submit  
-- **WHEN** Source Repo filled but scheme/host invalid OR `git:`/ssh-style disallowed patterns per implementation  
-- **AND** blur **or submit**  
-- **THEN** descriptive URL error shown; submit flow blocked when validation runs at submit.
+#### Scenario: Advanced collapsed by default
+- **WHEN** user selects **Single Repository**
+- **THEN** repo and commit fields are visible, Private repository appears before Advanced, and Advanced is collapsed until expanded.
+
+#### Scenario: Optional values on submit
+- **WHEN** user submits with non-empty Manifest path and/or selected language
+- **THEN** POST body includes `manifestPath` and/or `ecosystem`; when blank, values are omitted so agent autodetection applies.
+
+#### Scenario: Mode switch clears Advanced
+- **WHEN** user switches away from Single Repository
+- **THEN** Advanced values, errors, and expanded state are cleared.

--- a/openspec/specs/request-analysis-modal-single-repository/spec.md
+++ b/openspec/specs/request-analysis-modal-single-repository/spec.md
@@ -6,10 +6,10 @@
 ## Requirements
 
 ### Requirement: Single-repository submit and validation
-Submit SHALL require non-empty CVE, `sourceRepo`, and `commitId`. Repo URL validated HTTP/HTTPS on **blur or submit**. Success **HTTP 202**: build `ReportRequest` (CVE in `vulnerabilities`, trimmed repo/commit, metadata, optional `credential`, optional trimmed `manifestPath`/`ecosystem` when supplied), POST with `submit: true`, navigate `/reports/component/:cveId/:reportId`. HTTP **400** maps `cveId`, `sourceRepo`, `commitId`, `manifestPath`, `ecosystem`, credential to field errors; modal stays open.
+Submit SHALL require non-empty CVE, `sourceRepo`, and `commitId`. Repo URL validated HTTP/HTTPS on **blur or submit**. When non-empty, **Manifest path** SHALL be validated per **Manifest path security validation** on **blur or submit**. Success **HTTP 202**: build `ReportRequest` (CVE in `vulnerabilities`, trimmed repo/commit, metadata, optional `credential`, optional trimmed `manifestPath`/`ecosystem` when supplied and valid), POST with `submit: true`, navigate `/reports/component/:cveId/:reportId`. HTTP **400** maps `cveId`, `sourceRepo`, `commitId`, `manifestPath`, `ecosystem`, credential to field errors; modal stays open.
 
 #### Scenario: Happy path submits and navigates
-- **WHEN** valid CVE, HTTP(S) repo, Commit ID, and optional credential/Advanced fields empty or filled
+- **WHEN** valid CVE, HTTP(S) repo, Commit ID, and optional credential/Advanced fields empty or filled with valid values
 - **AND** user submits successfully
 - **THEN** POST `/reports/new` omitting blank Advanced values; on 202 navigate and close modal.
 
@@ -37,3 +37,37 @@ Single Repository SHALL show Source Repository and Commit ID, then **Private rep
 #### Scenario: Mode switch clears Advanced
 - **WHEN** user switches away from Single Repository
 - **THEN** Advanced values, errors, and expanded state are cleared.
+
+### Requirement: Manifest path security validation
+When the trimmed **Manifest path** is non-empty, the client SHALL validate it as a **relative path within the cloned repository** before submit. Validation SHALL run on **submit** and on **blur** (and **Enter** SHALL follow blur per parent modal **Keyboard Enter** requirement). Empty or whitespace-only values SHALL remain valid (field is optional; omitted from POST body). The client SHALL **reject** unsafe input with a descriptive field error and SHALL NOT call the API. Unsafe input includes:
+
+- Absolute paths (leading `/` or Windows drive-letter prefix such as `C:\` / `C:/`)
+- Backslash separators (`\`)
+- Any path segment equal to `..` (parent-directory traversal)
+- Null bytes
+
+Valid examples include `go.mod`, `services/api/go.mod`, and `./pkg/go.mod`. The client SHALL NOT silently rewrite or strip path segments; invalid input is rejected.
+
+#### Scenario: Valid relative manifest path submits
+- **WHEN** user enters a non-empty relative path without traversal segments (e.g. `services/api/go.mod`)
+- **AND** user submits with other required fields valid
+- **THEN** no manifest path field error is shown
+- **AND** POST body includes the trimmed `manifestPath`.
+
+#### Scenario: Parent-directory traversal blocked
+- **WHEN** user enters a manifest path containing a `..` segment (e.g. `../etc/passwd` or `foo/../bar`)
+- **AND** blur or submit runs validation
+- **THEN** a descriptive error appears under **Manifest path**
+- **AND** submit is blocked; API is not invoked.
+
+#### Scenario: Absolute path blocked
+- **WHEN** user enters an absolute manifest path (e.g. `/etc/passwd` or `C:\Windows\go.mod`)
+- **AND** blur or submit runs validation
+- **THEN** a descriptive error appears under **Manifest path**
+- **AND** submit is blocked; API is not invoked.
+
+#### Scenario: Empty manifest path remains optional
+- **WHEN** user leaves **Manifest path** empty or whitespace-only
+- **AND** user submits with other required fields valid
+- **THEN** no manifest path field error is shown
+- **AND** `manifestPath` is omitted from the POST body.

--- a/openspec/specs/request-analysis-modal/spec.md
+++ b/openspec/specs/request-analysis-modal/spec.md
@@ -11,7 +11,7 @@ Modal UI: `src/main/webui/src/components/request-analysis/`. Logic: `useAnalysis
 ## Requirements
 
 ### Requirement: Mode selector and shared layout
-The modal SHALL expose **SBOM**, **Single Repository**, and **RPM** via PatternFly `ToggleGroup`/`ToggleGroupItem` ("SBOM", "Single Repository", "RPM"), exactly one selected, meaningful `aria-label`, SBOM selected by default. Switching modes SHALL clear generic Alert errors and **all** field-specific errors **except `cveId`**. CVE ID SHALL always appear. Private repository controls SHALL follow **Private Repository Authentication** (including visibility rules when **RPM** is selected). SBOM mode shows file upload only; Single Repository shows Source Repo + Commit ID only; RPM mode shows Package NVR + Architecture only per **[RPM fields](../request-analysis-modal-rpm-fields/spec.md)**.
+The modal SHALL expose **SBOM**, **Single Repository**, and **RPM** via PatternFly `ToggleGroup`/`ToggleGroupItem` ("SBOM", "Single Repository", "RPM"), exactly one selected, meaningful `aria-label`, SBOM selected by default. Switching modes SHALL clear generic Alert errors and **all** field-specific errors **except `cveId`**. CVE ID SHALL always appear. Private repository controls SHALL follow **Private Repository Authentication** (including visibility rules when **RPM** is selected). SBOM mode shows file upload only; Single Repository shows Source Repo, Commit ID, Private repository, then collapsible **Advanced** per **[Single Repository](../request-analysis-modal-single-repository/spec.md)**; RPM mode shows Package NVR + Architecture only per **[RPM fields](../request-analysis-modal-rpm-fields/spec.md)**.
 
 #### Scenario: Mode switch clears non-CVE errors
 - **WHEN** the user switches among SBOM, Single Repository, and RPM via the toggle  
@@ -38,19 +38,23 @@ CVE ID MUST match `^CVE-[0-9]{4}-[0-9]{4,19}$` when validation runs for that fie
 - **THEN** CVE shows the format message and submission is blocked until resolved.
 
 ### Requirement: Keyboard Enter on modal text fields
-For **every** modal **PatternFly TextInput** (CVE ID, Source Repository, Commit ID, **Package NVR when RPM mode is active**, Authentication secret, Username), pressing **`Enter`** while focused SHALL **`preventDefault`** and SHALL invoke the **identical client validation/update paths** implemented for **`blur`** on that same field—including CVE format, Source Repo URL checks, RPM NVR parsing/validation **when RPM mode is active**, credential required/PAT username checks. **Excluded from this requirement:** **`FileUpload`**, **`ToggleGroup` / mode chooser**, **`Switch`**, **Architecture `Select`/dropdown**, other non-text controls. Fields with **no** blur validation rule today only receive **`preventDefault`** (currently **Commit ID**).
+For **every** modal **PatternFly TextInput** (CVE ID, Source Repository, Commit ID, **Manifest path when Single Repository Advanced is expanded**, **Package NVR when RPM mode is active**, Authentication secret, Username), pressing **`Enter`** while focused SHALL **`preventDefault`** and SHALL invoke the **identical client validation/update paths** implemented for **`blur`** on that same field—including CVE format, Source Repo URL checks, RPM NVR parsing/validation **when RPM mode is active**, credential required/PAT username checks. **Excluded:** **`FileUpload`**, **`ToggleGroup`**, **`Switch`**, **`ExpandableSection`**, **Architecture** and **Programming language** selects. Fields with no blur rule only receive **`preventDefault`** (**Commit ID**, **Manifest path**).
 
 #### Scenario: Enter matches blur for all modal TextInputs
-- **WHEN** focus is in any CVE, Source Repo, Commit ID, Package NVR (RPM mode), Authentication secret, or Username TextInput listed above  
-- **AND** the user presses Enter  
-- **THEN** Enter is intercepted (no unintended control action) AND each field behaves exactly as documented for blur for **that field** wherever blur rules exist; Commit ID invokes only interception.
+- **WHEN** focus is in any listed TextInput above
+- **AND** the user presses Enter
+- **THEN** Enter is intercepted and blur rules apply where defined; Commit ID and Manifest path intercept only.
 
 ### Requirement: Errors, loading, generic failures
-Editing a control clears **that field’s** error. Non-validation API failures (e.g. 429/500/network) ⇒ Alert; modal open; form preserved; submit re-enabled. While submit in-flight: duplicate submit prevented; disabling rules from private repo loading still apply (see sibling specs); cancel remains usable unless product rules say otherwise.
+Editing a control SHALL clear **that field’s** error. Non-validation API failures (e.g. 429/500/network) SHALL show an Alert; modal SHALL stay open with form preserved and submit re-enabled. While submit is in-flight, duplicate submit SHALL be prevented; private-repo disabling rules still apply; cancel SHALL remain usable unless product rules say otherwise.
 
 #### Scenario: Preserve form after non-field API error  
 - **WHEN** client validation passes and the API fails without field mapping  
 - **THEN** Alert shows a message; form values remain; loading ends.
 
 ### Requirement: Submit button
-Submit enabled if not submitting, mode-specific required inputs satisfied ([SBOM](../request-analysis-modal-sbom/spec.md) / [Single Repository](../request-analysis-modal-single-repository/spec.md) / [**RPM fields**](../request-analysis-modal-rpm-fields/spec.md)), and not blocked by Private repository empty secret rule when the active mode is **SBOM** or **Single Repository**.
+Submit SHALL be enabled when not submitting, mode-specific required inputs are satisfied ([SBOM](../request-analysis-modal-sbom/spec.md) / [Single Repository](../request-analysis-modal-single-repository/spec.md) / [**RPM fields**](../request-analysis-modal-rpm-fields/spec.md)), and not blocked by Private repository empty secret when mode is **SBOM** or **Single Repository**.
+
+#### Scenario: Submit disabled while in-flight
+- **WHEN** a submission is in progress
+- **THEN** Submit is disabled until the request completes.

--- a/openspec/specs/request-analysis-modal/spec.md
+++ b/openspec/specs/request-analysis-modal/spec.md
@@ -7,9 +7,7 @@ Mode-specific behaviors are specified in sibling capabilities: **[SBOM](../reque
 
 ## Implementation (non-normative)
 Modal UI: `src/main/webui/src/components/request-analysis/`. Logic: `useAnalysisRequestForm.ts`; helpers: `requestAnalysisValidation.ts`, `requestAnalysisRpm.ts`, `requestAnalysisSbom.ts`, `requestAnalysisSubmit.ts`.
-
 ## Requirements
-
 ### Requirement: Mode selector and shared layout
 The modal SHALL expose **SBOM**, **Single Repository**, and **RPM** via PatternFly `ToggleGroup`/`ToggleGroupItem` ("SBOM", "Single Repository", "RPM"), exactly one selected, meaningful `aria-label`, SBOM selected by default. Switching modes SHALL clear generic Alert errors and **all** field-specific errors **except `cveId`**. CVE ID SHALL always appear. Private repository controls SHALL follow **Private Repository Authentication** (including visibility rules when **RPM** is selected). SBOM mode shows file upload only; Single Repository shows Source Repo, Commit ID, Private repository, then collapsible **Advanced** per **[Single Repository](../request-analysis-modal-single-repository/spec.md)**; RPM mode shows Package NVR + Architecture only per **[RPM fields](../request-analysis-modal-rpm-fields/spec.md)**.
 
@@ -28,7 +26,7 @@ When the selected analysis mode is **RPM**, private-repository credential contro
 #### Scenario: RPM mode suppresses private repository UI
 - **WHEN** the selected mode is **RPM**  
 - **THEN** private-repository switch, secret, username controls, and their labels are not shown  
-- **AND** submit eligibility does not depend on private-repository credential state  
+- **AND** submit eligibility does not depend on private-repository credential state
 
 ### Requirement: CVE ID validation
 CVE ID MUST match `^CVE-[0-9]{4}-[0-9]{4,19}$` when validation runs for that field (including **blur** and **submit**). Invalid format ⇒ message explaining expected pattern ("CVE-YYYY…"). Empty required ⇒ *Required* on submit (aligned with tab specs).
@@ -38,12 +36,12 @@ CVE ID MUST match `^CVE-[0-9]{4}-[0-9]{4,19}$` when validation runs for that fie
 - **THEN** CVE shows the format message and submission is blocked until resolved.
 
 ### Requirement: Keyboard Enter on modal text fields
-For **every** modal **PatternFly TextInput** (CVE ID, Source Repository, Commit ID, **Manifest path when Single Repository Advanced is expanded**, **Package NVR when RPM mode is active**, Authentication secret, Username), pressing **`Enter`** while focused SHALL **`preventDefault`** and SHALL invoke the **identical client validation/update paths** implemented for **`blur`** on that same field—including CVE format, Source Repo URL checks, RPM NVR parsing/validation **when RPM mode is active**, credential required/PAT username checks. **Excluded:** **`FileUpload`**, **`ToggleGroup`**, **`Switch`**, **`ExpandableSection`**, **Architecture** and **Programming language** selects. Fields with no blur rule only receive **`preventDefault`** (**Commit ID**, **Manifest path**).
+For **every** modal **PatternFly TextInput** (CVE ID, Source Repository, Commit ID, **Manifest path when Single Repository Advanced is expanded**, **Package NVR when RPM mode is active**, Authentication secret, Username), pressing **`Enter`** while focused SHALL **`preventDefault`** and SHALL invoke the **identical client validation/update paths** implemented for **`blur`** on that same field—including CVE format, Source Repo URL checks, **Manifest path security validation when Single Repository Advanced is expanded**, RPM NVR parsing/validation **when RPM mode is active**, credential required/PAT username checks. **Excluded:** **`FileUpload`**, **`ToggleGroup`**, **`Switch`**, **`ExpandableSection`**, **Architecture** and **Programming language** selects. Fields with no blur rule only receive **`preventDefault`** (**Commit ID**).
 
 #### Scenario: Enter matches blur for all modal TextInputs
 - **WHEN** focus is in any listed TextInput above
 - **AND** the user presses Enter
-- **THEN** Enter is intercepted and blur rules apply where defined; Commit ID and Manifest path intercept only.
+- **THEN** Enter is intercepted and blur rules apply where defined; Commit ID intercepts only.
 
 ### Requirement: Errors, loading, generic failures
 Editing a control SHALL clear **that field’s** error. Non-validation API failures (e.g. 429/500/network) SHALL show an Alert; modal SHALL stay open with form preserved and submit re-enabled. While submit is in-flight, duplicate submit SHALL be prevented; private-repo disabling rules still apply; cancel SHALL remain usable unless product rules say otherwise.

--- a/src/main/webui/src/components/request-analysis/RequestAnalysisModal.tsx
+++ b/src/main/webui/src/components/request-analysis/RequestAnalysisModal.tsx
@@ -26,6 +26,7 @@ import RequestAnalysisModeToggle from "./RequestAnalysisModeToggle";
 import RequestAnalysisCveIdField from "./RequestAnalysisCveIdField";
 import RequestAnalysisSbomFileField from "./RequestAnalysisSbomFileField";
 import RequestAnalysisSingleRepositoryFields from "./RequestAnalysisSingleRepositoryFields";
+import RequestAnalysisSingleRepositoryAdvancedSection from "./RequestAnalysisSingleRepositoryAdvancedSection";
 import RequestAnalysisPrivateRepositorySection from "./RequestAnalysisPrivateRepositorySection";
 import RequestAnalysisRpmPackageField from "./RequestAnalysisRpmPackageField";
 import RequestAnalysisRpmArchitectureField from "./RequestAnalysisRpmArchitectureField";
@@ -110,6 +111,17 @@ const RequestAnalysisModal: React.FC<RequestAnalysisModalProps> = ({ onClose }) 
               authenticationSecretError={errors.authenticationSecret}
               username={values.username}
               usernameError={errors.username}
+              isSubmitting={state.isSubmitting}
+              handlers={handlers}
+            />
+          )}
+          {values.mode === "single-repository" && (
+            <RequestAnalysisSingleRepositoryAdvancedSection
+              isAdvancedExpanded={values.isAdvancedExpanded}
+              manifestPath={values.manifestPath}
+              manifestPathError={errors.manifestPath}
+              ecosystem={values.ecosystem}
+              ecosystemError={errors.ecosystem}
               isSubmitting={state.isSubmitting}
               handlers={handlers}
             />

--- a/src/main/webui/src/components/request-analysis/RequestAnalysisSingleRepositoryAdvancedSection.tsx
+++ b/src/main/webui/src/components/request-analysis/RequestAnalysisSingleRepositoryAdvancedSection.tsx
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from "react";
+import { ExpandableSection, FormSection } from "@patternfly/react-core";
+import type { AnalysisRequestFormSingleRepoAdvancedHandlers } from "../../hooks/useAnalysisRequestForm";
+import RequestAnalysisSingleRepositoryManifestPathField from "./RequestAnalysisSingleRepositoryManifestPathField";
+import RequestAnalysisSingleRepositoryProgrammingLanguageField from "./RequestAnalysisSingleRepositoryProgrammingLanguageField";
+
+export interface RequestAnalysisSingleRepositoryAdvancedSectionProps {
+  isAdvancedExpanded: boolean;
+  manifestPath: string;
+  manifestPathError: string | null;
+  ecosystem: string;
+  ecosystemError: string | null;
+  isSubmitting: boolean;
+  handlers: AnalysisRequestFormSingleRepoAdvancedHandlers;
+}
+
+const RequestAnalysisSingleRepositoryAdvancedSection: React.FC<
+  RequestAnalysisSingleRepositoryAdvancedSectionProps
+> = (props) => (
+  <ExpandableSection
+    toggleText="Advanced"
+    isExpanded={props.isAdvancedExpanded}
+    onToggle={props.handlers.onAdvancedToggle}
+    isWidthLimited
+  >
+    <FormSection>
+      <RequestAnalysisSingleRepositoryManifestPathField
+        manifestPath={props.manifestPath}
+        manifestPathError={props.manifestPathError}
+        isSubmitting={props.isSubmitting}
+        handlers={props.handlers}
+      />
+      <RequestAnalysisSingleRepositoryProgrammingLanguageField
+        ecosystem={props.ecosystem}
+        ecosystemError={props.ecosystemError}
+        isSubmitting={props.isSubmitting}
+        handlers={props.handlers}
+      />
+    </FormSection>
+  </ExpandableSection>
+);
+
+export default RequestAnalysisSingleRepositoryAdvancedSection;

--- a/src/main/webui/src/components/request-analysis/RequestAnalysisSingleRepositoryFields.tsx
+++ b/src/main/webui/src/components/request-analysis/RequestAnalysisSingleRepositoryFields.tsx
@@ -22,7 +22,14 @@ export interface RequestAnalysisSingleRepositoryFieldsProps {
 
 const RequestAnalysisSingleRepositoryFields: React.FC<
   RequestAnalysisSingleRepositoryFieldsProps
-> = ({ sourceRepo, sourceRepoError, commitId, commitIdError, isSubmitting, handlers }) => (
+> = ({
+  sourceRepo,
+  sourceRepoError,
+  commitId,
+  commitIdError,
+  isSubmitting,
+  handlers,
+}) => (
   <>
     <FormGroup label="Source Repository" isRequired fieldId="source-repo">
       <TextInput

--- a/src/main/webui/src/components/request-analysis/RequestAnalysisSingleRepositoryManifestPathField.tsx
+++ b/src/main/webui/src/components/request-analysis/RequestAnalysisSingleRepositoryManifestPathField.tsx
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from "react";
+import {
+  FormGroup,
+  TextInput,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from "@patternfly/react-core";
+import type { AnalysisRequestFormSingleRepoAdvancedHandlers } from "../../hooks/useAnalysisRequestForm";
+
+export interface RequestAnalysisSingleRepositoryManifestPathFieldProps {
+  manifestPath: string;
+  manifestPathError: string | null;
+  isSubmitting: boolean;
+  handlers: Pick<
+    AnalysisRequestFormSingleRepoAdvancedHandlers,
+    "onTextChange" | "onTextKeyDown"
+  >;
+}
+
+const RequestAnalysisSingleRepositoryManifestPathField: React.FC<
+  RequestAnalysisSingleRepositoryManifestPathFieldProps
+> = ({ manifestPath, manifestPathError, isSubmitting, handlers }) => (
+  <FormGroup label="Manifest path" fieldId="manifest-path">
+    <TextInput
+      type="text"
+      id="manifest-path"
+      name="manifest-path"
+      value={manifestPath}
+      onChange={(e, v) => handlers.onTextChange("manifestPath", e, v)}
+      onKeyDown={(e) => handlers.onTextKeyDown("manifestPath", e)}
+      placeholder="e.g. services/api/go.mod"
+      isDisabled={isSubmitting}
+      validated={manifestPathError ? "error" : "default"}
+    />
+    <FormHelperText>
+      <HelperText>
+        {manifestPathError && (
+          <HelperTextItem variant="error">{manifestPathError}</HelperTextItem>
+        )}
+      </HelperText>
+    </FormHelperText>
+  </FormGroup>
+);
+
+export default RequestAnalysisSingleRepositoryManifestPathField;

--- a/src/main/webui/src/components/request-analysis/RequestAnalysisSingleRepositoryProgrammingLanguageField.tsx
+++ b/src/main/webui/src/components/request-analysis/RequestAnalysisSingleRepositoryProgrammingLanguageField.tsx
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from "react";
+import {
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from "@patternfly/react-core";
+import {
+  SOURCE_ECOSYSTEM_CHOICES,
+  SOURCE_ECOSYSTEM_UNSET,
+} from "../../utils/requestAnalysisSource";
+import type { AnalysisRequestFormSingleRepoAdvancedHandlers } from "../../hooks/useAnalysisRequestForm";
+
+export interface RequestAnalysisSingleRepositoryProgrammingLanguageFieldProps {
+  ecosystem: string;
+  ecosystemError: string | null;
+  isSubmitting: boolean;
+  handlers: Pick<AnalysisRequestFormSingleRepoAdvancedHandlers, "onEcosystemChange">;
+}
+
+const RequestAnalysisSingleRepositoryProgrammingLanguageField: React.FC<
+  RequestAnalysisSingleRepositoryProgrammingLanguageFieldProps
+> = ({ ecosystem, ecosystemError, isSubmitting, handlers }) => (
+  <FormGroup label="Programming language" fieldId="programming-language">
+    <FormSelect
+      id="programming-language"
+      aria-label="Programming language"
+      value={ecosystem}
+      validated={ecosystemError ? "error" : "default"}
+      isDisabled={isSubmitting}
+      style={{ fontSize: "1rem" }}
+      onChange={(event, value) => handlers.onEcosystemChange(event, value)}
+    >
+      <FormSelectOption value={SOURCE_ECOSYSTEM_UNSET} label="Select language" isDisabled />
+      {SOURCE_ECOSYSTEM_CHOICES.map((choice) => (
+        <FormSelectOption key={choice} value={choice} label={choice} />
+      ))}
+    </FormSelect>
+    {ecosystemError && (
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem variant="error">{ecosystemError}</HelperTextItem>
+        </HelperText>
+      </FormHelperText>
+    )}
+  </FormGroup>
+);
+
+export default RequestAnalysisSingleRepositoryProgrammingLanguageField;

--- a/src/main/webui/src/hooks/useAnalysisRequestForm.ts
+++ b/src/main/webui/src/hooks/useAnalysisRequestForm.ts
@@ -13,6 +13,7 @@ import type { SbomValidationIssueEntry } from "../utils/errorHandling";
 import {
   validateCveIdFormat,
   validateSourceRepoUrl,
+  validateManifestPath,
   detectCredentialType,
 } from "../utils/requestAnalysisValidation";
 import {
@@ -68,7 +69,7 @@ export interface AnalysisRequestStoredValues extends AnalysisRequestFormValues {
 
 /**
  * Text inputs controlled via `handlers.onTextChange` / `onTextBlur` / `onTextKeyDown`.
- * Blur/`applyTextBlurValidation`: `commitId` no-ops (validated on submit only).
+ * Blur/`applyTextBlurValidation`: `commitId` no-ops (validated on submit only); `manifestPath` validated on blur when non-empty.
  */
 export type AnalysisRequestFormTextField = keyof Pick<
   AnalysisRequestStoredValues,
@@ -174,6 +175,13 @@ function getClientValidationErrors(s: AnalysisRequestStoredValues): Partial<Anal
     }
     if (s.commitId.trim() === "") {
       errors.commitId = VALIDATION_MESSAGE_REQUIRED;
+    }
+    const trimmedManifestPath = s.manifestPath.trim();
+    if (trimmedManifestPath !== "") {
+      const manifestPathError = validateManifestPath(trimmedManifestPath);
+      if (manifestPathError) {
+        errors.manifestPath = manifestPathError;
+      }
     }
   } else if (s.mode === "rpm") {
     const pkg = s.rpmPackageNvr.trim();
@@ -402,7 +410,18 @@ export function useAnalysisRequestForm({
     (field: AnalysisRequestFormTextField) => {
       switch (field) {
         case "commitId":
+          break;
         case "manifestPath":
+          setValues((v) => {
+            const trimmed = v.manifestPath.trim();
+            if (trimmed !== "") {
+              setErrors((e) => ({
+                ...e,
+                manifestPath: validateManifestPath(trimmed),
+              }));
+            }
+            return v;
+          });
           break;
         case "cveId":
           flushCveIdFormatValidation();

--- a/src/main/webui/src/hooks/useAnalysisRequestForm.ts
+++ b/src/main/webui/src/hooks/useAnalysisRequestForm.ts
@@ -29,6 +29,10 @@ import {
   unsupportedSbomFormatMessage,
 } from "../utils/requestAnalysisSbom";
 import { buildSbomFormData, uploadSbomFile } from "../utils/requestAnalysisSubmit";
+import {
+  isSourceEcosystemChoice,
+  SOURCE_ECOSYSTEM_UNSET,
+} from "../utils/requestAnalysisSource";
 
 const FALLBACK_ERROR_MESSAGE = "An error occurred while submitting the analysis request.";
 
@@ -49,6 +53,9 @@ export interface AnalysisRequestFormValues {
   commitId: string;
   rpmPackageNvr: string;
   rpmArch: RpmArchChoice;
+  isAdvancedExpanded: boolean;
+  manifestPath: string;
+  ecosystem: string;
   isAuthenticationSecretChecked: boolean;
   authenticationSecret: string;
   username: string;
@@ -65,7 +72,13 @@ export interface AnalysisRequestStoredValues extends AnalysisRequestFormValues {
  */
 export type AnalysisRequestFormTextField = keyof Pick<
   AnalysisRequestStoredValues,
-  "cveId" | "sourceRepo" | "commitId" | "rpmPackageNvr" | "authenticationSecret" | "username"
+  | "cveId"
+  | "sourceRepo"
+  | "commitId"
+  | "manifestPath"
+  | "rpmPackageNvr"
+  | "authenticationSecret"
+  | "username"
 >;
 
 export interface AnalysisRequestFormErrors {
@@ -74,6 +87,8 @@ export interface AnalysisRequestFormErrors {
   file: string | null;
   sourceRepo: string | null;
   commitId: string | null;
+  manifestPath: string | null;
+  ecosystem: string | null;
   rpmPackageNvr: string | null;
   rpmArch: string | null;
   authenticationSecret: string | null;
@@ -98,6 +113,8 @@ function createInitialFormErrors(): AnalysisRequestFormErrors {
     file: null,
     sourceRepo: null,
     commitId: null,
+    manifestPath: null,
+    ecosystem: null,
     rpmPackageNvr: null,
     rpmArch: null,
     authenticationSecret: null,
@@ -118,6 +135,9 @@ function createInitialStoredValues(): AnalysisRequestStoredValues {
     selectedFile: null,
     sourceRepo: "",
     commitId: "",
+    isAdvancedExpanded: false,
+    manifestPath: "",
+    ecosystem: SOURCE_ECOSYSTEM_UNSET,
     rpmPackageNvr: "",
     rpmArch: DEFAULT_RPM_ARCH,
     isAuthenticationSecretChecked: false,
@@ -218,6 +238,8 @@ export interface AnalysisRequestFormHandlers {
     event: React.KeyboardEvent<HTMLInputElement>
   ) => void;
   onRpmArchChange: (event: React.FormEvent<HTMLSelectElement>, value: string) => void;
+  onAdvancedToggle: (_event: React.MouseEvent, isExpanded: boolean) => void;
+  onEcosystemChange: (event: React.FormEvent<HTMLSelectElement>, value: string) => void;
   onPrivateRepoSwitch: (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => void;
   onFileInputChange: (_event: DropEvent, file: File) => void;
   onClearFile: (_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
@@ -260,6 +282,12 @@ export type AnalysisRequestFormModeHandlers = Pick<AnalysisRequestFormHandlers, 
 /** Handlers for RPM architecture `FormSelect`. */
 export type AnalysisRequestFormRpmArchHandlers = Pick<AnalysisRequestFormHandlers, "onRpmArchChange">;
 
+/** Handlers for single-repository Advanced section (manifest path, ecosystem). */
+export type AnalysisRequestFormSingleRepoAdvancedHandlers = Pick<
+  AnalysisRequestFormHandlers,
+  "onAdvancedToggle" | "onTextChange" | "onTextKeyDown" | "onEcosystemChange"
+>;
+
 export interface UseAnalysisRequestFormResult {
   values: AnalysisRequestFormValues;
   state: AnalysisRequestFormStateSlice;
@@ -286,15 +314,23 @@ export function useAnalysisRequestForm({
     }));
     setValues((prev) => {
       const nextMode = newMode;
+      let next: AnalysisRequestStoredValues = { ...prev, mode: nextMode };
       if (nextMode === "rpm" || prev.mode === "rpm") {
-        return {
-          ...prev,
-          mode: nextMode,
+        next = {
+          ...next,
           rpmPackageNvr: "",
           rpmArch: DEFAULT_RPM_ARCH,
         };
       }
-      return { ...prev, mode: nextMode };
+      if (nextMode === "single-repository" || prev.mode === "single-repository") {
+        next = {
+          ...next,
+          isAdvancedExpanded: false,
+          manifestPath: "",
+          ecosystem: SOURCE_ECOSYSTEM_UNSET,
+        };
+      }
+      return next;
     });
   }, []);
 
@@ -308,6 +344,8 @@ export function useAnalysisRequestForm({
       file: fieldErrors.file ?? null,
       sourceRepo: fieldErrors.sourceRepo ?? null,
       commitId: fieldErrors.commitId ?? null,
+      manifestPath: fieldErrors.manifestPath ?? fieldErrors.manifest_path ?? null,
+      ecosystem: fieldErrors.ecosystem ?? null,
       rpmPackageNvr: rpmCombined ?? null,
       rpmArch: fieldErrors.arch ?? null,
       sbomValidationIssues: issues && issues.length > 0 ? issues : null,
@@ -345,10 +383,26 @@ export function useAnalysisRequestForm({
     []
   );
 
+  const onAdvancedToggle = useCallback((_event: React.MouseEvent, isExpanded: boolean) => {
+    setValues((prev) => ({ ...prev, isAdvancedExpanded: isExpanded }));
+  }, []);
+
+  const onEcosystemChange = useCallback(
+    (_event: React.FormEvent<HTMLSelectElement>, value: string) => {
+      if (value !== SOURCE_ECOSYSTEM_UNSET && !isSourceEcosystemChoice(value)) {
+        return;
+      }
+      setValues((prev) => ({ ...prev, ecosystem: value }));
+      setErrors((prev) => (prev.ecosystem ? { ...prev, ecosystem: null } : prev));
+    },
+    []
+  );
+
   const applyTextBlurValidation = useCallback(
     (field: AnalysisRequestFormTextField) => {
       switch (field) {
         case "commitId":
+        case "manifestPath":
           break;
         case "cveId":
           flushCveIdFormatValidation();
@@ -473,6 +527,8 @@ export function useAnalysisRequestForm({
       setState({ isSubmitting: true });
       try {
         const credential = getCredentialForSubmit(values);
+        const trimmedManifestPath = values.manifestPath.trim();
+        const trimmedEcosystem = values.ecosystem.trim();
         const requestBody: ReportRequest = {
           analysisType: "source",
           vulnerabilities: [trimmedCveId],
@@ -480,6 +536,8 @@ export function useAnalysisRequestForm({
           sourceRepo: values.sourceRepo.trim(),
           commitId: values.commitId.trim(),
           credential,
+          ...(trimmedManifestPath !== "" ? { manifestPath: trimmedManifestPath } : {}),
+          ...(trimmedEcosystem !== "" ? { ecosystem: trimmedEcosystem } : {}),
         };
         const response: ReportData = await ReportEndpointService.postApiV1ReportsNew({
           requestBody,
@@ -589,6 +647,8 @@ export function useAnalysisRequestForm({
       onTextBlur,
       onTextKeyDown,
       onRpmArchChange,
+      onAdvancedToggle,
+      onEcosystemChange,
       onPrivateRepoSwitch,
       onFileInputChange,
       onClearFile,
@@ -600,6 +660,8 @@ export function useAnalysisRequestForm({
       onTextBlur,
       onTextKeyDown,
       onRpmArchChange,
+      onAdvancedToggle,
+      onEcosystemChange,
       onPrivateRepoSwitch,
       onFileInputChange,
       onClearFile,

--- a/src/main/webui/src/utils/requestAnalysisSource.ts
+++ b/src/main/webui/src/utils/requestAnalysisSource.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/** Agent OpenAPI `Ecosystem` enum values for single-repository analysis. */
+export const SOURCE_ECOSYSTEM_CHOICES = ["go", "python", "javascript", "java", "c"] as const;
+
+export type SourceEcosystemChoice = (typeof SOURCE_ECOSYSTEM_CHOICES)[number];
+
+export const SOURCE_ECOSYSTEM_UNSET = "";
+
+export function isSourceEcosystemChoice(value: string): value is SourceEcosystemChoice {
+  return (SOURCE_ECOSYSTEM_CHOICES as readonly string[]).includes(value);
+}

--- a/src/main/webui/src/utils/requestAnalysisValidation.ts
+++ b/src/main/webui/src/utils/requestAnalysisValidation.ts
@@ -39,6 +39,39 @@ export function validateSourceRepoUrl(value: string): string | null {
   }
 }
 
+/** Windows drive-letter absolute path prefix (e.g. C:\ or C:/) */
+const MANIFEST_PATH_WINDOWS_ABSOLUTE = /^[A-Za-z]:[/\\]/;
+
+/**
+ * Validates manifest path as a relative path within the cloned repository.
+ * Rejects absolute paths, backslashes, parent-directory segments, and null bytes.
+ * @returns Error message if invalid, null if valid or empty (empty is optional on submit)
+ */
+export function validateManifestPath(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return null;
+  }
+  if (trimmed.startsWith("/")) {
+    return "Manifest path must be a relative path within the repository";
+  }
+  if (MANIFEST_PATH_WINDOWS_ABSOLUTE.test(trimmed)) {
+    return "Manifest path must be a relative path within the repository";
+  }
+  if (trimmed.includes("\\")) {
+    return "Manifest path must use forward slashes only";
+  }
+  if (trimmed.includes("\0")) {
+    return "Manifest path contains invalid characters";
+  }
+  for (const segment of trimmed.split("/")) {
+    if (segment === "..") {
+      return "Manifest path must not contain parent directory references (..)";
+    }
+  }
+  return null;
+}
+
 /**
  * Auto-detects credential type based on content (matches backend InlineCredential.detectType()).
  */

--- a/src/main/webui/src/utils/requestAnalysisValidation.ts
+++ b/src/main/webui/src/utils/requestAnalysisValidation.ts
@@ -39,7 +39,11 @@ export function validateSourceRepoUrl(value: string): string | null {
   }
 }
 
-/** Windows drive-letter absolute path prefix (e.g. C:\ or C:/) */
+/**
+ * Windows drive-letter absolute path prefix (e.g. C:\ or C:/).
+ * Rejected as invalid input for the Linux agent container—not a path-traversal
+ * mitigation; such paths cannot resolve to files inside the cloned repository.
+ */
 const MANIFEST_PATH_WINDOWS_ABSOLUTE = /^[A-Za-z]:[/\\]/;
 
 /**


### PR DESCRIPTION
### Summary
Adds optional Advanced controls to the Request Analysis modal in Single Repository mode so users can target monorepo subpaths and hint programming language without cluttering the default form.

- Advanced collapsible section (collapsed by default), placed after `Private repository`

- **Manifest path** - optional text field for a path within the cloned repo. supports monorepo analysis

- **Programming language** - optional single-select dropdown with agent Ecosystem values: `go, python, javascript, java, c;` unset placeholder Select language

- Both fields are optional; blank values are omitted on submit so the agent can autodetect ecosystem

- Form state wired through `useAnalysisRequestForm`; non-empty values sent as manifestPath and ecosystem on POST _/api/v1/reports/new_

- Advanced state resets when leaving Single Repository mode

- OpenSpec updated for request-analysis-modal and request-analysis-modal-single-repository

- No backend API changes :  `ReportRequest `already supports these fields and `ReportService` forwards them to the agent.

[JIRA](https://redhat.atlassian.net/issues?filter=106533&selectedIssue=APPENG-5110)