### PR TITLE
Run maven-test only after mongodb-setup

### DIFF
--- a/.tekton/on-pull-request.yaml
+++ b/.tekton/on-pull-request.yaml
@@ -83,7 +83,6 @@ spec:
             value: setup
       - name: maven-test
         runAfter:
-          - fetch-repository
           - mongodb-setup
         taskRef:
           name: maven-test-ci


### PR DESCRIPTION
Remove redundant fetch-repository from maven-test runAfter since mongodb-setup already depends on clone. Tests should explicitly wait for ephemeral mongodb to be ready, not on fetch-repository directly.