### PR TITLE
 Add GHSA-based ecosystem detection and dominant language fallback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@
       <artifactId>quarkus-junit5-component</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/client/GitHubService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/client/GitHubService.java
@@ -14,15 +14,19 @@
 
 package com.redhat.ecosystemappeng.morpheus.client;
 
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 import jakarta.ws.rs.Encoded;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
 
 @RegisterRestClient(configKey = "github")
 public interface GitHubService {
@@ -34,6 +38,24 @@ public interface GitHubService {
   @GET
   @Path("/repos/{repository}/languages")
   Map<String, Integer> getLanguages(@PathParam("repository") @Encoded String repository,
+      @HeaderParam("Authorization") String authorization);
+
+  @GET
+  @Path("/advisories")
+  List<JsonNode> getAdvisories(@QueryParam("cve_id") String cveId);
+
+  @GET
+  @Path("/advisories")
+  List<JsonNode> getAdvisories(@QueryParam("cve_id") String cveId,
+      @HeaderParam("Authorization") String authorization);
+
+  @GET
+  @Path("/advisories")
+  List<JsonNode> getAdvisoriesByGhsaId(@QueryParam("ghsa_id") String ghsaId);
+
+  @GET
+  @Path("/advisories")
+  List<JsonNode> getAdvisoriesByGhsaId(@QueryParam("ghsa_id") String ghsaId,
       @HeaderParam("Authorization") String authorization);
 
 }

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ReportService.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -86,6 +87,18 @@ public class ReportService {
   private static final String PACKAGE_TYPE_PROPERTY = "syft:package:type";
   private static final Pattern PURL_PKG_TYPE = Pattern.compile("pkg\\:(\\w+)\\/.*");
   public static final String HOSTED_GITHUB_COM = "github.com";
+
+  private static final Map<String, String> GHSA_TO_LANGUAGE = Map.of(
+      "MAVEN", "Java", "NPM", "JavaScript", "GO", "Go",
+      "PIP", "Python", "PYPI", "Python");
+
+  private static final Map<String, String> GHSA_TO_ECOSYSTEM = Map.of(
+      "MAVEN", "java", "NPM", "javascript", "GO", "go",
+      "PIP", "python", "PYPI", "python");
+
+  private static final Map<String, String> LANGUAGE_TO_ECOSYSTEM = Map.of(
+      "Java", "java", "JavaScript", "javascript", "TypeScript", "javascript",
+      "Go", "go", "Python", "python", "C", "c", "C++", "c");
 
   @RestClient
   GitHubService gitHubService;
@@ -483,23 +496,39 @@ public class ReportService {
       commitId = request.commitId();
     }
     Set<String> languages;
-    if (sourceLocation.contains(HOSTED_GITHUB_COM)) {
-      var credential = request.credential();
-      if (Objects.nonNull(credential) && Objects.nonNull(credential.userName())) {
-        languages = getGitHubLanguages(sourceLocation, "Bearer " + credential.secretValue());
-      } else if(!globalGithubApiKey.isEmpty()){
-        languages = getGitHubLanguages(sourceLocation, "Bearer " + globalGithubApiKey.trim());
-      }
-      else {
-        languages = getGitHubLanguages(sourceLocation);
-      }
-      if (languages.isEmpty() && Objects.nonNull(request.ecosystem()) && !request.ecosystem().trim().isEmpty()) {
-        LOGGER.infof("No languages detected from GitHub for %s, using ecosystem: %s", sourceLocation, request.ecosystem());
-        languages = buildLanguagesExtensions(request.ecosystem());
-      }
-    }
-    else {
+    if (Objects.nonNull(request.ecosystem()) && !request.ecosystem().trim().isEmpty()) {
       languages = buildLanguagesExtensions(request.ecosystem());
+      LOGGER.infof("Using user-provided ecosystem for %s: %s", sourceLocation, request.ecosystem());
+    } else {
+      var ghsaResult = getEcosystemFromGhsa(request.vulnerabilities());
+      if (!ghsaResult.languages().isEmpty()) {
+        languages = ghsaResult.languages();
+        ecosystem = ghsaResult.pipelineEcosystem() != null ? ghsaResult.pipelineEcosystem() : ecosystem;
+        LOGGER.infof("Detected ecosystem from GHSA for %s: %s", sourceLocation, ecosystem);
+      } else if (sourceLocation.contains(HOSTED_GITHUB_COM)) {
+        var credential = request.credential();
+        Map<String, Integer> langMap;
+        if (Objects.nonNull(credential) && Objects.nonNull(credential.userName())) {
+          langMap = getGitHubLanguages(sourceLocation, "Bearer " + credential.secretValue());
+        } else if (!globalGithubApiKey.isEmpty()) {
+          langMap = getGitHubLanguages(sourceLocation, "Bearer " + globalGithubApiKey.trim());
+        } else {
+          langMap = getGitHubLanguages(sourceLocation);
+        }
+        languages = langMap.keySet();
+        var dominantEcosystem = langMap.entrySet().stream()
+            .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+            .map(e -> LANGUAGE_TO_ECOSYSTEM.get(e.getKey()))
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+        if (dominantEcosystem != null) {
+          ecosystem = dominantEcosystem;
+          LOGGER.infof("Detected dominant ecosystem from GitHub Language API for %s: %s", sourceLocation, ecosystem);
+        }
+      } else {
+        languages = buildLanguagesExtensions("");
+      }
     }
 
     var allIncludes = languages.stream().map(includes::get).filter(Objects::nonNull).flatMap(Collection::stream)
@@ -631,23 +660,23 @@ public class ReportService {
     return null;
   }
 
-  private Set<String> getGitHubLanguages(String repository) {
+  private Map<String, Integer> getGitHubLanguages(String repository) {
     var repoName = repository.replace("https://github.com/", "");
     if (repoName.endsWith(".git")) {
       repoName = repoName.substring(0, repoName.length() - 4);
     }
     try {
       LOGGER.debugf("looking for programming languages for repository %s (using system token)", repoName);
-      return gitHubService.getLanguages(repoName).keySet();
+      return gitHubService.getLanguages(repoName);
     } catch (ClientWebApplicationException e) {
       int status = e.getResponse().getStatus();
       if (status == Response.Status.NOT_FOUND.getStatusCode()) {
         LOGGER.infof("Repository not found or is private (no user token provided): %s", repoName);
-        return Collections.emptySet();
+        return Collections.emptyMap();
       }
       if (status == Response.Status.UNAUTHORIZED.getStatusCode() || status == Response.Status.FORBIDDEN.getStatusCode()) {
         LOGGER.infof("Insufficient permissions to access repository: %s (status=%d)", repoName, status);
-        return Collections.emptySet();
+        return Collections.emptyMap();
       }
       LOGGER.error("Unable to retrieve programming languages", e);
       throw e;
@@ -657,18 +686,78 @@ public class ReportService {
     }
   }
 
-  private Set<String> getGitHubLanguages(String repository, String authorization) {
+  private Map<String, Integer> getGitHubLanguages(String repository, String authorization) {
     var repoName = repository.replace("https://github.com/", "");
     try {
       LOGGER.debugf("looking for programming languages for repository %s (with user token)", repoName);
-      return gitHubService.getLanguages(repoName, authorization).keySet();
+      return gitHubService.getLanguages(repoName, authorization);
     } catch (Exception e) {
       LOGGER.warnf(
           "Unable to retrieve programming languages for repository %s, falling back to all supported languages (%s)",
           repository,
           e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
-      return Collections.emptySet();
+      return Collections.emptyMap();
     }
+  }
+
+  private record GhsaEcosystemResult(Set<String> languages, String pipelineEcosystem) {
+    static final GhsaEcosystemResult EMPTY = new GhsaEcosystemResult(Collections.emptySet(), null);
+  }
+
+  private GhsaEcosystemResult getEcosystemFromGhsa(Collection<String> vulnIds) {
+    if (vulnIds == null || vulnIds.isEmpty()) {
+      return GhsaEcosystemResult.EMPTY;
+    }
+    for (String vulnId : vulnIds) {
+      try {
+        List<JsonNode> advisories;
+        if (vulnId.toUpperCase().startsWith("GHSA-")) {
+          advisories = globalGithubApiKey.isEmpty()
+              ? gitHubService.getAdvisoriesByGhsaId(vulnId)
+              : gitHubService.getAdvisoriesByGhsaId(vulnId, "Bearer " + globalGithubApiKey.trim());
+        } else {
+          advisories = globalGithubApiKey.isEmpty()
+              ? gitHubService.getAdvisories(vulnId)
+              : gitHubService.getAdvisories(vulnId, "Bearer " + globalGithubApiKey.trim());
+        }
+        if (advisories == null || advisories.isEmpty()) {
+          continue;
+        }
+        Set<String> languages = new HashSet<>();
+        String pipelineEcosystem = null;
+        for (JsonNode advisory : advisories) {
+          JsonNode vulnerabilities = advisory.get("vulnerabilities");
+          if (vulnerabilities == null || !vulnerabilities.isArray()) {
+            continue;
+          }
+          for (JsonNode vuln : vulnerabilities) {
+            JsonNode pkg = vuln.get("package");
+            if (pkg == null) {
+              continue;
+            }
+            JsonNode ecosystemNode = pkg.get("ecosystem");
+            if (ecosystemNode == null || ecosystemNode.isNull()) {
+              continue;
+            }
+            String ghsaEcosystem = ecosystemNode.asText().toUpperCase();
+            String lang = GHSA_TO_LANGUAGE.get(ghsaEcosystem);
+            if (lang != null) {
+              languages.add(lang);
+              if (pipelineEcosystem == null) {
+                pipelineEcosystem = GHSA_TO_ECOSYSTEM.get(ghsaEcosystem);
+              }
+            }
+          }
+        }
+        if (!languages.isEmpty()) {
+          return new GhsaEcosystemResult(languages, pipelineEcosystem);
+        }
+      } catch (Exception e) {
+        LOGGER.warnf("Unable to retrieve GHSA advisory for %s: %s", vulnId,
+            e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+      }
+    }
+    return GhsaEcosystemResult.EMPTY;
   }
 
   /**

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ReportService.java
@@ -503,7 +503,7 @@ public class ReportService {
       var ghsaResult = getEcosystemFromGhsa(request.vulnerabilities());
       if (!ghsaResult.languages().isEmpty()) {
         languages = ghsaResult.languages();
-        ecosystem = ghsaResult.pipelineEcosystem() != null ? ghsaResult.pipelineEcosystem() : ecosystem;
+        ecosystem = Objects.nonNull(ghsaResult.pipelineEcosystem()) ? ghsaResult.pipelineEcosystem() : ecosystem;
         LOGGER.infof("Detected ecosystem from GHSA for %s: %s", sourceLocation, ecosystem);
       } else if (sourceLocation.contains(HOSTED_GITHUB_COM)) {
         var credential = request.credential();
@@ -522,7 +522,7 @@ public class ReportService {
             .filter(Objects::nonNull)
             .findFirst()
             .orElse(null);
-        if (dominantEcosystem != null) {
+        if (Objects.nonNull(dominantEcosystem)) {
           ecosystem = dominantEcosystem;
           LOGGER.infof("Detected dominant ecosystem from GitHub Language API for %s: %s", sourceLocation, ecosystem);
         }
@@ -705,7 +705,7 @@ public class ReportService {
   }
 
   private GhsaEcosystemResult getEcosystemFromGhsa(Collection<String> vulnIds) {
-    if (vulnIds == null || vulnIds.isEmpty()) {
+    if (Objects.isNull(vulnIds) || vulnIds.isEmpty()) {
       return GhsaEcosystemResult.EMPTY;
     }
     for (String vulnId : vulnIds) {
@@ -720,30 +720,30 @@ public class ReportService {
               ? gitHubService.getAdvisories(vulnId)
               : gitHubService.getAdvisories(vulnId, "Bearer " + globalGithubApiKey.trim());
         }
-        if (advisories == null || advisories.isEmpty()) {
+        if (Objects.isNull(advisories) || advisories.isEmpty()) {
           continue;
         }
         Set<String> languages = new HashSet<>();
         String pipelineEcosystem = null;
         for (JsonNode advisory : advisories) {
           JsonNode vulnerabilities = advisory.get("vulnerabilities");
-          if (vulnerabilities == null || !vulnerabilities.isArray()) {
+          if (Objects.isNull(vulnerabilities) || !vulnerabilities.isArray()) {
             continue;
           }
           for (JsonNode vuln : vulnerabilities) {
             JsonNode pkg = vuln.get("package");
-            if (pkg == null) {
+            if (Objects.isNull(pkg)) {
               continue;
             }
             JsonNode ecosystemNode = pkg.get("ecosystem");
-            if (ecosystemNode == null || ecosystemNode.isNull()) {
+            if (Objects.isNull(ecosystemNode) || ecosystemNode.isNull()) {
               continue;
             }
             String ghsaEcosystem = ecosystemNode.asText().toUpperCase();
             String lang = GHSA_TO_LANGUAGE.get(ghsaEcosystem);
-            if (lang != null) {
+            if (Objects.nonNull(lang)) {
               languages.add(lang);
-              if (pipelineEcosystem == null) {
+              if (Objects.isNull(pipelineEcosystem)) {
                 pipelineEcosystem = GHSA_TO_ECOSYSTEM.get(ghsaEcosystem);
               }
             }
@@ -754,7 +754,7 @@ public class ReportService {
         }
       } catch (Exception e) {
         LOGGER.warnf("Unable to retrieve GHSA advisory for %s: %s", vulnId,
-            e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+            Objects.nonNull(e.getMessage()) ? e.getMessage() : e.getClass().getSimpleName());
       }
     }
     return GhsaEcosystemResult.EMPTY;

--- a/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/morpheus/service/ReportService.java
@@ -695,7 +695,7 @@ public class ReportService {
       LOGGER.warnf(
           "Unable to retrieve programming languages for repository %s, falling back to all supported languages (%s)",
           repository,
-          e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+          Objects.nonNull(e.getMessage()) ? e.getMessage() : e.getClass().getSimpleName());
       return Collections.emptyMap();
     }
   }
@@ -707,6 +707,9 @@ public class ReportService {
   private GhsaEcosystemResult getEcosystemFromGhsa(Collection<String> vulnIds) {
     if (Objects.isNull(vulnIds) || vulnIds.isEmpty()) {
       return GhsaEcosystemResult.EMPTY;
+    }
+    if (globalGithubApiKey.isEmpty()) {
+      LOGGER.warn("No GitHub API key configured; GHSA advisory lookups may be rate-limited");
     }
     for (String vulnId : vulnIds) {
       try {

--- a/src/test/java/com/redhat/ecosystemappeng/morpheus/rest/UploadSpdxMockedSyftRestTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/morpheus/rest/UploadSpdxMockedSyftRestTest.java
@@ -1,0 +1,89 @@
+package com.redhat.ecosystemappeng.morpheus.rest;
+
+import static org.hamcrest.Matchers.*;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.ecosystemappeng.morpheus.model.ParsedCycloneDx;
+import com.redhat.ecosystemappeng.morpheus.service.GenerateSbomService;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+/**
+ * SPDX upload tests that mock {@link GenerateSbomService} to avoid real syft/registry calls.
+ */
+@QuarkusTest
+public class UploadSpdxMockedSyftRestTest {
+
+    private static final String SPDX_WITH_UNSUPPORTED = "src/test/resources/devservices/spdx-sboms/spdx-with-unsupported-component.json";
+    private static final String CYCLONEDX_FIXTURE = "src/test/resources/devservices/cyclonedx-sboms/nmstate-rhel8-operator.json";
+    private static final String TEST_VULN_ID = "CVE-2021-4238";
+
+    @InjectMock
+    GenerateSbomService generateSbomService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        RestApiTestFixture.configureRestAssuredIfExternal();
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode sbomJson = mapper.readTree(new File(CYCLONEDX_FIXTURE));
+        JsonNode component = sbomJson.get("metadata").get("component");
+
+        ParsedCycloneDx mockSbom = new ParsedCycloneDx(
+            sbomJson,
+            component.get("name").asText(),
+            component.has("version") ? component.get("version").asText() : null,
+            component.has("description") ? component.get("description").asText() : null,
+            component.has("type") ? component.get("type").asText() : null,
+            component.has("purl") ? component.get("purl").asText() : null,
+            component.has("bom-ref") ? component.get("bom-ref").asText() : null);
+
+        Mockito.when(generateSbomService.generate(Mockito.anyString()))
+            .thenReturn(mockSbom);
+    }
+
+    @Test
+    void testUpload_SpdxWithUnsupportedComponent_RecordsInSubmissionFailures() {
+        File sbomFile = new File(SPDX_WITH_UNSUPPORTED);
+
+        String productId = RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart("cveId", TEST_VULN_ID)
+            .multiPart("file", sbomFile)
+            .when()
+            .post("/api/v1/products/upload-spdx")
+            .then()
+            .statusCode(202)
+            .contentType(ContentType.JSON)
+            .body("productId", notNullValue())
+            .extract()
+            .path("productId");
+
+        Assertions.assertNotNull(productId, "Product ID should not be null");
+        RestApiTestFixture.awaitSpdxProductProcessingComplete(productId);
+
+        RestAssured.given()
+            .when()
+            .get("/api/v1/products/" + productId)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("data.submittedCount", equalTo(2))
+            .body("data.submissionFailures", notNullValue())
+            .body("data.submissionFailures", hasSize(1))
+            .body("data.submissionFailures[0].name", equalTo("maven-lib"))
+            .body("data.submissionFailures[0].version", equalTo("2.0"))
+            .body("data.submissionFailures[0].error", containsString("Expects a container image purl with format pkg:oci/name@sha256:hash?repository_url=...&tag=..."));
+    }
+}

--- a/src/test/java/com/redhat/ecosystemappeng/morpheus/rest/UploadSpdxRestTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/morpheus/rest/UploadSpdxRestTest.java
@@ -26,7 +26,6 @@ public class UploadSpdxRestTest {
     }
 
     private static final String TEST_SBOM_FILE = "src/test/resources/devservices/spdx-sboms/gitops-1.19.json";
-    private static final String SPDX_WITH_UNSUPPORTED = "src/test/resources/devservices/spdx-sboms/spdx-with-unsupported-component.json";
     private static final String INVALID_SPDX_DIR = "src/test/resources/devservices/spdx-sboms/invalid";
     private static final String TEST_VULN_ID = "CVE-2021-4238";
 
@@ -87,40 +86,6 @@ public class UploadSpdxRestTest {
             .then()
             .statusCode(200)
             .header("X-Total-Elements", String.valueOf(GITOPS_119_EXPECTED_REPORT_COUNT));
-    }
-
-    @Test
-    void testUpload_SpdxWithUnsupportedComponent_RecordsInSubmissionFailures() {
-        File sbomFile = new File(SPDX_WITH_UNSUPPORTED);
-
-        String productId = RestAssured.given()
-            .contentType(ContentType.MULTIPART)
-            .multiPart("cveId", TEST_VULN_ID)
-            .multiPart("file", sbomFile)
-            .when()
-            .post("/api/v1/products/upload-spdx")
-            .then()
-            .statusCode(202)
-            .contentType(ContentType.JSON)
-            .body("productId", notNullValue())
-            .extract()
-            .path("productId");
-
-        Assertions.assertNotNull(productId, "Product ID should not be null");
-        RestApiTestFixture.awaitSpdxProductProcessingComplete(productId);
-
-        RestAssured.given()
-            .when()
-            .get("/api/v1/products/" + productId)
-            .then()
-            .statusCode(200)
-            .contentType(ContentType.JSON)
-            .body("data.submittedCount", equalTo(2))
-            .body("data.submissionFailures", notNullValue())
-            .body("data.submissionFailures", hasSize(1))
-            .body("data.submissionFailures[0].name", equalTo("maven-lib"))
-            .body("data.submissionFailures[0].version", equalTo("2.0"))
-            .body("data.submissionFailures[0].error", containsString("Expects a container image purl with format pkg:oci/name@sha256:hash?repository_url=...&tag=..."));
     }
 
     @Test


### PR DESCRIPTION
  - Add GHSA advisory API methods to GitHubService (by CVE ID and GHSA ID, with/without auth)
  - Add GHSA ecosystem-to-language mappings (MAVEN→Java, NPM→JavaScript, GO→Go, PIP/PYPI→Python)
  - Add getEcosystemFromGhsa() method to extract ecosystem from GHSA advisory vulnerabilities
  - Reorder ecosystem resolution: user input → GHSA advisory → GitHub Language API → ALL languages
  - Return full language byte-count map from GitHub Language API instead of just key set
  - Detect dominant ecosystem from GitHub Language API by highest byte count
  - Add LANGUAGE_TO_ECOSYSTEM mapping for GitHub Language API language names