### PR TITLE
test: pin mongodb devservices image to 8.0.3-ubi8

### DIFF
--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -9,6 +9,7 @@
 %test.quarkus.oidc.enabled=false
 %test.morpheus.credential-store.encryption-key=dev-test-key-must-be-32bytes-long!
 %test.quarkus.quinoa.enabled=false
+%test.quarkus.mongodb.devservices.image-name=docker.io/mongodb/mongodb-community-server:8.0.3-ubi8
 %test.quarkus.wiremock.devservices.reload=true
 %test.quarkus.wiremock.devservices.files-mapping=src/test/resources/devservices/wiremock
 # WireMock dev service logs full request/response bodies at INFO; raise level to avoid huge test logs.


### PR DESCRIPTION
Pins MongoDB DevServices container image to `docker.io/mongodb/mongodb-community-server:8.0.3-ubi8` aligned with https://github.com/RHEcosystemAppEng/vulnerability-analysis/blob/main/kustomize/base/exploit_iq_client_db.yaml