### PR TITLE
chore: bump quarkus to 3.36.2 and update build image to mandrel-25

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -60,6 +60,10 @@ src/test/
 
 # Quinoa
 .quinoa
+src/main/webui/node_modules
+src/main/webui/dist
+src/main/webui/.quinoa
+src/main/webui/.env
 
 # Data
 data/

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.29.4</quarkus.platform.version>
+    <quarkus.platform.version>3.36.2</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.5.2</surefire-plugin.version>
-    <quarkus-quinoa.version>2.7.0</quarkus-quinoa.version>
+    <quarkus-quinoa.version>2.8.3</quarkus-quinoa.version>
   </properties>
 
   <dependencyManagement>
@@ -112,7 +112,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -122,7 +122,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-component</artifactId>
+      <artifactId>quarkus-junit-component</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -160,6 +160,7 @@
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
           </systemPropertyVariables>
+          <argLine>@{argLine}</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -179,6 +180,7 @@
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
           </systemPropertyVariables>
+          <argLine>@{argLine}</argLine>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/docker/Dockerfile.multi-stage
+++ b/src/main/docker/Dockerfile.multi-stage
@@ -1,5 +1,7 @@
 ## Stage 1 : build with maven builder image with native capabilities
-FROM registry.redhat.io/quarkus/mandrel-for-jdk-21-rhel8:23.1 AS build
+# Quarkus 3.36+ requires Mandrel/GraalVM 25+ for native builds:
+# https://quarkus.io/blog/mandrel-25-minimum-version
+FROM registry.redhat.io/quarkus/mandrel-25-rhel9@sha256:b19bdb7a74ed8827d5bc97dd95386da862a57571f7e8c2b77347912fdc0578f3 AS build
 
 # Build profile - affects build-time properties only
 # Default: prod (OpenShift OAuth). Override with --build-arg QUARKUS_PROFILE=external-idp


### PR DESCRIPTION
- Bump `quarkus.platform.version` from 3.29.4 to 3.36.2. Closes #242 in a more proper way
- Update native build image to `mandrel-25-rhel9` (required for Quarkus 3.36+ https://quarkus.io/blog/mandrel-25-minimum-version)
- Add webui build artifacts to `.dockerignore`

The upgrade was performed using the [standard](https://quarkus.io/guides/update-quarkus#procedure) `quarkus update` command