### PR TITLE
fix: reject special characters in Request Analysis RPM Package N-V-R field

### DIFF
--- a/src/main/webui/src/utils/requestAnalysisRpm.ts
+++ b/src/main/webui/src/utils/requestAnalysisRpm.ts
@@ -17,16 +17,24 @@ export function isRpmArchChoice(value: string | undefined): value is RpmArchChoi
   return value !== undefined && RPM_ARCH_CHOICES.includes(value as RpmArchChoice);
 }
 
-/** Letters, digits, hyphens, dots, and underscores — rejects @, #, $, %, spaces, etc. */
-const RPM_PACKAGE_NVR_ALLOWED_CHARS = /^[a-zA-Z0-9._-]+$/;
+/** RPM Name: alphanumerics and -, _, ., + (rpm-spec.5). */
+const RPM_NAME_PATTERN = /^[a-zA-Z0-9._+-]+$/;
+
+/** RPM Version/Release: alphanumerics, ., _, +, ~, ^ — no hyphen (rpm-version.7). */
+const RPM_VERSION_RELEASE_PATTERN = /^[a-zA-Z0-9._+~^]+$/;
+
+function isValidRpmName(value: string): boolean {
+  return RPM_NAME_PATTERN.test(value);
+}
+
+function isValidRpmVersionOrRelease(value: string): boolean {
+  return RPM_VERSION_RELEASE_PATTERN.test(value);
+}
 
 /** Parses a trimmed RPM N-V-R: release after last hyphen, version before that, name is the leading remainder (may contain hyphens). */
 export function parseTrimmedRpmNvr(
   trimmed: string
 ): { name: string; version: string; release: string } | null {
-  if (!RPM_PACKAGE_NVR_ALLOWED_CHARS.test(trimmed)) {
-    return null;
-  }
   const lastHyphen = trimmed.lastIndexOf("-");
   if (lastHyphen <= 0) {
     return null;
@@ -40,6 +48,9 @@ export function parseTrimmedRpmNvr(
   const name = remainder.slice(0, secondHyphen).trim();
   const version = remainder.slice(secondHyphen + 1).trim();
   if (name === "" || version === "" || release === "") {
+    return null;
+  }
+  if (!isValidRpmName(name) || !isValidRpmVersionOrRelease(version) || !isValidRpmVersionOrRelease(release)) {
     return null;
   }
   return { name, version, release };

--- a/src/main/webui/src/utils/requestAnalysisRpm.ts
+++ b/src/main/webui/src/utils/requestAnalysisRpm.ts
@@ -17,10 +17,16 @@ export function isRpmArchChoice(value: string | undefined): value is RpmArchChoi
   return value !== undefined && RPM_ARCH_CHOICES.includes(value as RpmArchChoice);
 }
 
+/** Letters, digits, hyphens, dots, and underscores — rejects @, #, $, %, spaces, etc. */
+const RPM_PACKAGE_NVR_ALLOWED_CHARS = /^[a-zA-Z0-9._-]+$/;
+
 /** Parses a trimmed RPM N-V-R: release after last hyphen, version before that, name is the leading remainder (may contain hyphens). */
 export function parseTrimmedRpmNvr(
   trimmed: string
 ): { name: string; version: string; release: string } | null {
+  if (!RPM_PACKAGE_NVR_ALLOWED_CHARS.test(trimmed)) {
+    return null;
+  }
   const lastHyphen = trimmed.lastIndexOf("-");
   if (lastHyphen <= 0) {
     return null;


### PR DESCRIPTION

**Description:**
When users submit an RPM analysis request from the Request Analysis modal (RPM tab), the Package N-V-R field should reject values that contain invalid characters (e.g. @, #, $, %, spaces).

**Problem:**
Users can paste container-style references such as `instructlab-nvidia-rhel9@sha984750942850`. These are not valid RPM N-V-R coordinates but could pass basic hyphen-based parsing.

**Solution:**
Add client-side validation so the trimmed package string only allows letters, digits, hyphens (-), dots (.), and underscores (_). Invalid input blocks submit and shows the existing N-V-R format error message.

[Jira](https://redhat.atlassian.net/issues?filter=106533&selectedIssue=APPENG-5503)