### PR TITLE
chore: upgrade to node-version 24.14.1

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ exploit-iq.image.source.location-keys=image.source-location,io.openshift.build.s
 exploit-iq.image.source.commit-id-keys=image.source.commit-id,io.openshift.build.commit.id,upstream-source-ref,org.opencontainers.image.revision
 
 quarkus.quinoa.package-manager-install=true
-quarkus.quinoa.package-manager-install.node-version=20.10.0
+quarkus.quinoa.package-manager-install.node-version=24.14.1
 quarkus.quinoa.enable-spa-routing=true
 %dev.quarkus.quinoa.dev-server.enabled=true
 


### PR DESCRIPTION
- Align with the actual Node.js releases (https://nodejs.org/en/about/previous-releases)
- Update to the Node.js 24 LTS version
- [Jira](https://redhat.atlassian.net/issues?filter=-1&selectedIssue=APPENG-5539)