### PR TITLE
chore: rename quarkus-junit5-mockito to quarkus-junit-mockito

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Artifact relocated per Quarkus 3.31 migration guide.

- `quarkus-junit5-mockito` -> `quarkus-junit-mockito` in `pom.xml`
- Warning in the build logs `[WARNING] The artifact io.quarkus:quarkus-junit5-mockito:jar:3.36.2 has been relocated to io.quarkus:quarkus-junit-mockito:jar:3.36.2: Update the artifactId in your project build file. Refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31 for more information.`

Ref: https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31#junit-6-gear-white_check_mark