### PR TITLE
fix: accept url-encoded colon in OCI purl sha256 digest

### DIFF
--- a/docs/sbom-requirements.md
+++ b/docs/sbom-requirements.md
@@ -38,6 +38,8 @@ An SPDX product SBOM MUST:
 
   `pkg:oci/<name>@sha256:<digest>?repository_url=<registry>/<path>&tag=<tag>`
 
+  Per the [OCI purl specification](https://github.com/package-url/purl-spec/blob/main/docs/types/definitions/oci-definition.md), the colon in the digest may also be URL-encoded as `%3A` (for example `@sha256%3A<digest>`). Both forms are accepted.
+
 At least one component with a valid OCI `purl` is required; components without an OCI `purl` are excluded from analysis.
 
 Optionally, the product package MAY include a CPE in `externalRefs` (`referenceCategory` `SECURITY`, `referenceType` `cpe22Type`). If the CPE exists, it will be stored in the product metadata.

--- a/openspec/specs/upload-spdx-api/spec.md
+++ b/openspec/specs/upload-spdx-api/spec.md
@@ -108,3 +108,8 @@ When parsing an SPDX file, the system SHALL classify each component (package wit
 - **AND** the upload endpoint SHALL return HTTP 400 (Bad Request)
 - **AND** the response body SHALL include `"file": "At least one supported component is required. Supported components are packages with a PACKAGE_OF relationship to the product that have a purl (package URL) starting with pkg:oci. No such components were found."`
 
+#### Scenario: OCI purl with URL-encoded sha256 separator is supported
+- **WHEN** the SPDX parser processes a component whose OCI purl uses a URL-encoded colon in the version segment (for example `@sha256%3A<digest>` instead of `@sha256:<digest>`)
+- **THEN** the parser SHALL treat the component as supported
+- **AND** the parser SHALL normalize the image reference to use an unencoded `sha256:` digest separator for downstream container pull
+

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/SbomReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/SbomReportService.java
@@ -238,9 +238,9 @@ public class SbomReportService {
     int totalComponentCount = parsed.components().size() + parsed.unsupportedComponents().size();
     Product product = this.createProduct(cveId, productInfo.name(), productInfo.version(), totalComponentCount, metadata);
 
-    for (SpdxParsingService.UnsupportedComponentInfo unsupported : parsed.unsupportedComponents()) {      
-      String errorMessage = String.format(
-          "Expects a container image purl with format pkg:oci/name@sha256:hash or pkg:oci/name@sha256%3Ahash?repository_url=...&tag=...");
+    for (SpdxParsingService.UnsupportedComponentInfo unsupported : parsed.unsupportedComponents()) {
+      String errorMessage =
+          "Expects a container image purl with format pkg:oci/name@sha256:hash or pkg:oci/name@sha256%3Ahash?repository_url=...&tag=...";
       String imageForDisplay = unsupported.purl() != null ? unsupported.purl() : "";
       productRepository.addSubmissionFailure(product.id(), new FailedComponent(
           unsupported.name(), unsupported.version(), imageForDisplay, errorMessage));

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/SbomReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/SbomReportService.java
@@ -240,7 +240,7 @@ public class SbomReportService {
 
     for (SpdxParsingService.UnsupportedComponentInfo unsupported : parsed.unsupportedComponents()) {      
       String errorMessage = String.format(
-          "Expects a container image purl with format pkg:oci/name@sha256:hash?repository_url=...&tag=...");
+          "Expects a container image purl with format pkg:oci/name@sha256:hash or pkg:oci/name@sha256%3Ahash?repository_url=...&tag=...");
       String imageForDisplay = unsupported.purl() != null ? unsupported.purl() : "";
       productRepository.addSubmissionFailure(product.id(), new FailedComponent(
           unsupported.name(), unsupported.version(), imageForDisplay, errorMessage));

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/SpdxParsingService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/SpdxParsingService.java
@@ -247,6 +247,7 @@ public class SpdxParsingService {
 
   /**
    * Parses image from OCI PURL format: pkg:oci/name@sha256:hash?repository_url=...&tag=...
+   * The digest separator may be a literal colon or URL-encoded as {@code %3A} per the OCI purl spec.
    * Returns: repository_url@sha256:hash
    */
   private String parseImageFromPurl(String purl) {
@@ -254,20 +255,20 @@ public class SpdxParsingService {
       return null;
     }
 
-    // Extract SHA256 from @sha256:... part
-    int shaIndex = purl.indexOf("@sha256:");
-    if (shaIndex == -1) {
+    int atIndex = purl.indexOf('@');
+    if (atIndex == -1) {
       return null;
     }
-    
-    int shaEndIndex = purl.indexOf("?", shaIndex);
-    if (shaEndIndex == -1) {
-      shaEndIndex = purl.length();
+
+    int queryIndex = purl.indexOf('?', atIndex);
+    int versionEndIndex = queryIndex == -1 ? purl.length() : queryIndex;
+    String versionPart = purl.substring(atIndex + 1, versionEndIndex);
+    String sha = java.net.URLDecoder.decode(versionPart, java.nio.charset.StandardCharsets.UTF_8);
+    if (!sha.startsWith("sha256:")) {
+      return null;
     }
-    String sha = purl.substring(shaIndex + 1, shaEndIndex); // +1 to skip @, includes sha256:hash
 
     // Extract repository_url from query parameters
-    int queryIndex = purl.indexOf("?");
     if (queryIndex == -1) {
       return null;
     }

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/UploadSpdxMockedSyftRestTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/UploadSpdxMockedSyftRestTest.java
@@ -84,6 +84,6 @@ public class UploadSpdxMockedSyftRestTest {
                 .body("data.submissionFailures", hasSize(1))
                 .body("data.submissionFailures[0].name", equalTo("maven-lib"))
                 .body("data.submissionFailures[0].version", equalTo("2.0"))
-                .body("data.submissionFailures[0].error", containsString("Expects a container image purl with format pkg:oci/name@sha256:hash?repository_url=...&tag=..."));
+                .body("data.submissionFailures[0].error", containsString("Expects a container image purl with format pkg:oci/name@sha256:hash"));
     }
 }

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/SpdxParsingServiceTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/SpdxParsingServiceTest.java
@@ -2,6 +2,7 @@ package com.redhat.ecosystemappeng.exploitiq.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -58,5 +59,73 @@ class SpdxParsingServiceTest {
     JsonNode root = objectMapper.readTree(Files.readString(fixture));
     SbomValidationException ex = assertThrows(SbomValidationException.class, () -> service.parse(root));
     assertEquals("No DESCRIBES relationship found in SPDX document", ex.getMessage());
+  }
+
+  @Test
+  void parse_acceptsOciPurlWithUrlEncodedSha256Separator() throws Exception {
+    String json = """
+        {
+          "spdxVersion": "SPDX-2.3",
+          "packages": [
+            {"SPDXID": "SPDXRef-Product", "name": "test-product", "versionInfo": "1.0"},
+            {
+              "SPDXID": "SPDXRef-Component",
+              "name": "ubi9-micro",
+              "versionInfo": "1.0",
+              "externalRefs": [{
+                "referenceCategory": "PACKAGE_MANAGER",
+                "referenceType": "purl",
+                "referenceLocator": "pkg:oci/ubi9-micro@sha256%3A1c8483e0fda0e990175eb9855a5f15e0910d2038dd397d9e2b357630f0321e6d?arch=amd64&repository_url=registry.access.redhat.com/ubi9-micro&tag=9.4-6.1716471860"
+              }]
+            }
+          ],
+          "relationships": [
+            {"spdxElementId": "SPDXRef-DOCUMENT", "relatedSpdxElement": "SPDXRef-Product", "relationshipType": "DESCRIBES"},
+            {"spdxElementId": "SPDXRef-Component", "relatedSpdxElement": "SPDXRef-Product", "relationshipType": "PACKAGE_OF"}
+          ]
+        }
+        """;
+    JsonNode root = objectMapper.readTree(json);
+    SpdxParsingService.ParsedSpdx parsed = service.parse(root);
+
+    assertEquals(1, parsed.components().size());
+    assertTrue(parsed.unsupportedComponents().isEmpty());
+    assertEquals(
+        "registry.access.redhat.com/ubi9-micro@sha256:1c8483e0fda0e990175eb9855a5f15e0910d2038dd397d9e2b357630f0321e6d",
+        parsed.components().get(0).image());
+  }
+
+  @Test
+  void parse_acceptsOciPurlWithUnencodedSha256Separator() throws Exception {
+    String json = """
+        {
+          "spdxVersion": "SPDX-2.3",
+          "packages": [
+            {"SPDXID": "SPDXRef-Product", "name": "test-product", "versionInfo": "1.0"},
+            {
+              "SPDXID": "SPDXRef-Component",
+              "name": "dex-rhel8",
+              "versionInfo": "1.0",
+              "externalRefs": [{
+                "referenceCategory": "PACKAGE_MANAGER",
+                "referenceType": "purl",
+                "referenceLocator": "pkg:oci/dex-rhel8@sha256:442508af831dd69f0bdfde9065c8bf2776abf5d37786467528f696e372f5d996?repository_url=registry.redhat.io/openshift-gitops-1/dex-rhel8&tag=v1.19.0"
+              }]
+            }
+          ],
+          "relationships": [
+            {"spdxElementId": "SPDXRef-DOCUMENT", "relatedSpdxElement": "SPDXRef-Product", "relationshipType": "DESCRIBES"},
+            {"spdxElementId": "SPDXRef-Component", "relatedSpdxElement": "SPDXRef-Product", "relationshipType": "PACKAGE_OF"}
+          ]
+        }
+        """;
+    JsonNode root = objectMapper.readTree(json);
+    SpdxParsingService.ParsedSpdx parsed = service.parse(root);
+
+    assertEquals(1, parsed.components().size());
+    assertTrue(parsed.unsupportedComponents().isEmpty());
+    assertEquals(
+        "registry.redhat.io/openshift-gitops-1/dex-rhel8@sha256:442508af831dd69f0bdfde9065c8bf2776abf5d37786467528f696e372f5d996",
+        parsed.components().get(0).image());
   }
 }


### PR DESCRIPTION
## Summary

### The Bug:
The client is rejecting a valid OCI purl because its failing to parse it. The following purl is valid: 
`pkg:oci/ubi9-micro@sha256%3A1c8483e0fda0e990175eb9855a5f15e0910d2038dd397d9e2b357630f0321e6d?arch=amd64&repository_url=registry.access.redhat.com/ubi9-micro&tag=9.4-6.1716471860` 
but is failing to parse properly by agent-morpheus-client because it expects `sha256:` instead of `sha256%3A`. 
Both are valid and both should be parsed correctly

### The fix: 
- Fix `SpdxParsingService.parseImageFromPurl` to accept OCI purls where the digest separator is URL-encoded as `%3A` (e.g. `@sha256%3A...`), per the [OCI purl spec](https://github.com/package-url/purl-spec/blob/main/docs/types/definitions/oci-definition.md)
- Normalize parsed image references to unencoded `sha256:` for downstream Syft/container pull
- Add unit tests for both `%3A` and unencoded `@sha256:` forms
- Clarify `docs/sbom-requirements.md` and upload-spdx openspec that both encodings are accepted

[Jira](https://redhat.atlassian.net/browse/APPENG-5634)

