### PR TITLE
fix(sse): add keepalive heartbeat to prevent proxy idle-timeout disconnects

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,16 @@ exploit-iq.syncer.timeout=1h # duration to wait for component syncer during pre-
 
 Set this value according to the expected processing time for your product. If the syncer does not finish within the configured timeout, any components still pending will be marked as expired.
 
+## SSE keepalive heartbeat
+
+The live-update SSE stream (`/api/v1/reports/stream`) keeps a long-lived HTTP connection open. Proxies and load balancers (including OpenShift's HAProxy ingress) close idle connections after their configured timeout. To prevent unexpected disconnects, the server periodically emits an SSE comment line that counts as activity for the proxy but is silently discarded by the browser.
+
+```properties
+exploit-iq.sse.heartbeat-interval=25S # how often to send the keepalive comment
+```
+
+Set this value to less than the proxy's idle-connection timeout (`timeout server` in HAProxy). The default is defined in `application.properties`. Accepts standard duration notation: `25S`, `1M`, `PT30S`.
+
 ## Purge
 
 You can activate the purge for old reports. By default is disabled and unless the

--- a/openspec/specs/report-events-stream/spec.md
+++ b/openspec/specs/report-events-stream/spec.md
@@ -1,23 +1,27 @@
 # report-events-stream Specification
 
 ## Purpose
-Push **catalog** invalidation from the Quarkus app to the browser so report and product views refetch over REST when MongoDB-backed data changes. The web UI does not poll on a timer for this; it listens on a single authenticated SSE endpoint and refetches existing REST queries when events arrive.
+Push invalidation signals from the Quarkus app to the browser so report and product views refetch over REST when MongoDB-backed data changes. The web UI does not poll on a timer for this; it listens on a single authenticated SSE endpoint and refetches existing REST queries when events arrive.
 
 ## Requirements
 
 ### Requirement: Authenticated SSE endpoint
-The backend SHALL expose `GET /api/v1/reports/stream` (JAX-RS path `/reports/stream` under the application REST root `quarkus.rest.path=/api/v1`) with `Content-Type: text/event-stream`, each stream element serialized as JSON (`ReportSseMessage`). The endpoint SHALL use the same JWT security as other `/api/v1` resources (`ReportStreamResource`).
+The backend SHALL expose `GET /api/v1/reports/stream` (JAX-RS path `/reports/stream` under the application REST root `quarkus.rest.path=/api/v1`) with `Content-Type: text/event-stream`. The endpoint SHALL use the same JWT security as other `/api/v1` resources (`ReportStreamResource`).
+
+The stream carries two kinds of frames:
+- **Named data events** (`event: update`, `data: {}`): signal that report or product data may have changed; clients SHALL refetch their current REST queries on receipt.
+- **SSE comment lines** (`: keepalive`): emitted periodically (default every 25 s, configurable via `exploit-iq.sse.heartbeat-interval`) to prevent proxy idle-connection timeouts (e.g. HAProxy `timeout server 30s`); browsers discard them and they SHALL NOT trigger any application logic.
 
 #### Scenario: Client opens a long-lived stream
 - **WHEN** a browser issues `GET /api/v1/reports/stream` with valid authentication
-- **THEN** the server keeps the connection open and pushes JSON SSE elements until the client disconnects or the server drops the subscriber (e.g. emit failure)
+- **THEN** the server keeps the connection open, emits `: keepalive` comment lines periodically, and pushes `event: update` frames when report or product data changes, until the client disconnects or the server drops the subscriber (e.g. emit failure)
 
 ### Requirement: Live-update event payload
-Each emitted item SHALL serialize as JSON `ReportSseMessage`, which today is the empty object `{}` . The presence of an event SHALL mean report or product data that affects lists or detail views may have changed; clients SHOULD refetch their current REST queries. A future version MAY add explicit fields (for example event kind, `reportId`, `productId`) for targeted invalidation, emitted only from write paths that know those identifiers.
+Data events SHALL use SSE named-event format: `event: update` followed by `data: {}` (serialized `ReportSseMessage`). The presence of an `update` event SHALL mean report or product data that affects lists or detail views may have changed; clients SHOULD refetch their current REST queries. A future version MAY add explicit fields (for example `reportId`, `productId`) for targeted invalidation, emitted only from write paths that know those identifiers.
 
 #### Scenario: Coarse invalidation signal
 - **WHEN** the application publishes a live update
-- **THEN** subscribers receive an SSE `data` line whose JSON is `{}` and clients SHOULD treat cached report/product data as possibly stale
+- **THEN** subscribers receive an `event: update` frame whose JSON data is `{}` and clients SHOULD treat cached report/product data as possibly stale
 
 ### Requirement: Server-side fan-out
 The application SHALL use an application-scoped `ReportSseBroadcaster` that registers one Mutiny `Multi` emitter per connected stream and broadcasts each `ReportSseMessage` to all active emitters. Subscribers SHALL be held in a thread-safe collection suitable for concurrent iteration (e.g. `CopyOnWriteArrayList`). If emitting to a subscriber fails, that subscriber SHALL be removed so other clients are unaffected.
@@ -28,19 +32,23 @@ The application SHALL use an application-scoped `ReportSseBroadcaster` that regi
 - **THEN** each connected client receives that message on its own stream
 
 ### Requirement: Emit after persistence
-`publishCatalogChanged()` SHALL be invoked from report and product repository layers after MongoDB writes that affect lists or catalog views (including report lifecycle updates, removals, product save/remove, product `completed_at` updates, and submission-failure bookkeeping). When product `completed_at` is updated in the same logical flow as a report mutation that already ends with `publishCatalogChanged()`, the implementation SHALL persist that product field without its own publish so the flow emits one live-update event, not two.
+`publishCatalogChanged()` SHALL be invoked from report and product repository layers after MongoDB writes that affect list or detail views (including report lifecycle updates, removals, product save/remove, product `completed_at` updates, and submission-failure bookkeeping). When product `completed_at` is updated in the same logical flow as a report mutation that already ends with `publishCatalogChanged()`, the implementation SHALL persist that product field without its own publish so the flow emits one live-update event, not two.
 
 #### Scenario: Callback drives UI refresh
-- **WHEN** this app persists report or product document changes that affect catalog or list views
-- **THEN** connected browsers receive at least one live-update event aligned with that persistence (and SHOULD refetch their current REST queries)
+- **WHEN** this app persists report or product document changes that affect list or detail views
+- **THEN** connected browsers receive at least one `event: update` frame aligned with that persistence (and SHOULD refetch their current REST queries)
 
 ### Requirement: Web client single EventSource via React context
-The web UI SHALL open exactly one browser `EventSource` for the live-updates stream (`REPORTS_LIVE_UPDATES_SSE_PATH` in `src/main/webui/src/constants/sse.ts`), owned by `LiveUpdatesProvider` (`src/main/webui/src/contexts/LiveUpdatesContext.tsx`) mounted in `App.tsx` above `BrowserRouter`. The provider SHALL use `withCredentials: true`. Hooks (`useApi`, `usePaginatedApi`) that opt in with `liveUpdatesRefresh` SHALL observe ticks via `useLiveUpdatesRevision` and `useSyncExternalStore` so only those hooks re-render on stream messages, not the entire app. There SHALL be no per-hook `EventSource`, no configurable alternate stream URL, and no subscribe/unsubscribe registry outside React. The UI SHALL treat any SSE message as a tick (it does not depend on payload fields today).
+The web UI SHALL open exactly one browser `EventSource` for the live-updates stream (`REPORTS_LIVE_UPDATES_SSE_PATH` in `src/main/webui/src/constants/sse.ts`), owned by `LiveUpdatesProvider` (`src/main/webui/src/contexts/LiveUpdatesContext.tsx`) mounted in `App.tsx` above `BrowserRouter`. The provider SHALL use `withCredentials: true`. The provider SHALL listen for `event: update` frames via `EventSource.addEventListener("update", ...)` and increment a monotonic revision counter on each. SSE comment frames (`: keepalive`) SHALL be discarded by the browser automatically and SHALL NOT increment the counter or trigger any refetch. Hooks (`useApi`, `usePaginatedApi`) that opt in with `liveUpdatesRefresh` SHALL observe ticks via `useLiveUpdatesRevision` and `useSyncExternalStore` so only those hooks re-render on stream messages, not the entire app. There SHALL be no per-hook `EventSource`, no configurable alternate stream URL, and no subscribe/unsubscribe registry outside React.
 
 #### Scenario: One TCP connection per browser session
 - **WHEN** the app shell mounts with `LiveUpdatesProvider`
 - **THEN** one `EventSource` connects to the live-updates stream and stays open for the provider lifetime
 
 #### Scenario: Hooks refetch on live-update ticks
-- **WHEN** a hook uses `liveUpdatesRefresh: true` and the live-updates revision increments after an SSE message
+- **WHEN** a hook uses `liveUpdatesRefresh: true` and the live-updates revision increments after an `event: update` frame
 - **THEN** the hook refetches (subject to `shouldRefresh` when provided, and paginated debounce rules when applicable)
+
+#### Scenario: Keepalive comments do not trigger refetch
+- **WHEN** the server emits a `: keepalive` SSE comment
+- **THEN** the browser discards it silently; no revision increment occurs and no hook refetches

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/config/AppConfig.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/config/AppConfig.java
@@ -38,6 +38,12 @@ public interface AppConfig {
     Optional<Engine> engine();
     Optional<Database> database();
     Optional<Audit> audit();
+    Optional<SseConfig> sse();
+
+    interface SseConfig {
+        @WithName("heartbeat-interval")
+        Duration heartbeatInterval();
+    }
 
     interface Image {
         Source source();

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportStreamResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportStreamResource.java
@@ -1,5 +1,7 @@
 package com.redhat.ecosystemappeng.exploitiq.rest;
 
+import java.time.Duration;
+
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -9,6 +11,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
 
+import com.redhat.ecosystemappeng.exploitiq.config.AppConfig;
 import com.redhat.ecosystemappeng.exploitiq.model.ReportSseMessage;
 import com.redhat.ecosystemappeng.exploitiq.service.ReportSseBroadcaster;
 
@@ -18,25 +21,46 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import org.jboss.resteasy.reactive.RestStreamElementType;
+import jakarta.ws.rs.sse.OutboundSseEvent;
+import jakarta.ws.rs.sse.Sse;
 
 @SecurityScheme(securitySchemeName = "jwt", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT", description = "Please enter your JWT Token without Bearer")
 @SecurityRequirement(name = "jwt")
 @Path("/reports")
 public class ReportStreamResource {
 
+  private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofSeconds(25);
+
+  @Inject
+  AppConfig appConfig;
+
   @Inject
   ReportSseBroadcaster broadcaster;
+
+  @Inject
+  Sse sse;
 
   @GET
   @Path("/stream")
   @Produces(MediaType.SERVER_SENT_EVENTS)
-  @RestStreamElementType(MediaType.APPLICATION_JSON)
-  @Operation(summary = "Report live-update stream (SSE)", description = "Server-Sent Events. Each event `data` line is JSON `{}` (empty object): report or product data may have changed; clients should refetch their REST views. The payload may gain fields later for targeted invalidation.")
+  @Operation(summary = "Report live-update stream (SSE)", description = "Server-Sent Events. Named events `event: update` signal that report or product data may have changed; clients should refetch their REST views. SSE comment lines (`:keepalive`) are emitted every 25 s to prevent proxy idle-connection timeouts.")
   @APIResponses({
       @APIResponse(responseCode = "200", description = "SSE stream", content = @Content(schema = @Schema(implementation = ReportSseMessage.class)))
   })
-  public Multi<ReportSseMessage> stream() {
-    return broadcaster.subscribe();
+  public Multi<OutboundSseEvent> stream() {
+    Multi<OutboundSseEvent> updates = broadcaster.subscribe()
+        .map(msg -> sse.newEventBuilder()
+            .name("update")
+            .mediaType(MediaType.APPLICATION_JSON_TYPE)
+            .data(msg)
+            .build());
+
+    Duration interval = appConfig.sse()
+        .map(cfg -> cfg.heartbeatInterval())
+        .orElse(DEFAULT_HEARTBEAT_INTERVAL);
+    Multi<OutboundSseEvent> heartbeats = Multi.createFrom().ticks().every(interval)
+        .map(tick -> sse.newEventBuilder().comment("keepalive").build());
+
+    return Multi.createBy().merging().streams(updates, heartbeats);
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -174,6 +174,9 @@ quarkus.micrometer.binder.http-server.ignore-patterns=^(?!/reports).*$
 #quarkus.opentelemetry.tracer.exporter.otlp.enabled=false
 quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n
 
+# SSE keepalive interval; must be lower than ingress/proxy idle timeout to prevent stream disconnects
+exploit-iq.sse.heartbeat-interval=25S
+
 # Queue settings
 exploit-iq.queue.max-active=20
 exploit-iq.queue.timeout=2h

--- a/src/main/webui/src/contexts/LiveUpdatesContext.tsx
+++ b/src/main/webui/src/contexts/LiveUpdatesContext.tsx
@@ -21,7 +21,13 @@ export type LiveUpdatesStore = {
 const LiveUpdatesContext = createContext<LiveUpdatesStore | null>(null);
 
 /**
- * Owns one {@link EventSource} for the server push stream that signals report/product data may have changed.
+ * Owns one {@link EventSource} for the server-sent events stream at {@link REPORTS_LIVE_UPDATES_SSE_PATH}.
+ *
+ * The server emits two kinds of frames:
+ *  - `event: update` - report or product data may have changed; triggers a revision bump so hooks re-fetch.
+ *  - SSE comment lines (`: keepalive`) - sent periodically to prevent proxy idle-timeout disconnects;
+ *    the browser discards them and they never reach this listener.
+ *
  * Hooks opt in with `liveUpdatesRefresh` on `useApi` / `usePaginatedApi` and observe bumps via `useLiveUpdatesRevision`.
  */
 export function LiveUpdatesProvider({ children }: { children: ReactNode }) {
@@ -37,9 +43,9 @@ export function LiveUpdatesProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const url = `${window.location.origin}${REPORTS_LIVE_UPDATES_SSE_PATH}`;
     const es = new EventSource(url, { withCredentials: true });
-    es.onmessage = () => {
+    es.addEventListener("update", () => {
       bump();
-    };
+    });
     es.onerror = (event) => {
       console.error(
         "[LiveUpdates] EventSource error",


### PR DESCRIPTION
The SSE stream at `/api/v1/reports/stream` had no heartbeat. HAProxy (default OpenShift ingress) drops idle connections after 30 s (`timeout client 30s` / `timeout server 30s`), causing `ERR_INCOMPLETE_CHUNKED_ENCODING` in the browser. The `EventSource` API auto-reconnects, creating an infinite error loop visible in the console.

##  How to test

HAProxy simulation (matches default OpenShift ingress `timeout server 30s`):
  ```bash
  # Write config
  cat > /tmp/haproxy.cfg << 'HAPROXY'
  global
  defaults
    mode http
    timeout connect 5s
    timeout client 30s
    timeout server 30s
  frontend fe
    bind *:9090
    default_backend be
  backend be
    server quarkus 127.0.0.1:8080
  HAPROXY

  # Start HAProxy (Linux - uses host network to reach localhost:8080)
  docker run --rm --network=host -v /tmp/haproxy.cfg:/tmp/h.cfg haproxy:2.8 haproxy -f /tmp/h.cfg -db
  ```
  ```bash
  # In another terminal
  curl -N -H "Accept: text/event-stream" http://localhost:9090/api/v1/reports/stream
  # connection must survive past 30 s and print `: keepalive`
  ```