### PR TITLE
docs(mongodb): add external MongoDB connection guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Check this other documents for:
 
 * [Configuration](./docs/configuration.md)
 * [Development](./docs/development.md)
+* [Connecting to MongoDB](./docs/connecting-to-mongodb.md) — configuring ExploitIQ to connect to an external or self-managed MongoDB instance
 * [SBOM Requirements](./docs/sbom-requirements.md) — SPDX 2.3 structure, OCI image labels, and example fixtures
 * [Tests](./src/test/README.md) — REST `@QuarkusTest` notes and CI test image for pipelines
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,16 +36,9 @@ will depend on the preffix used in the report ID.
 
 ## Database (MongoDB)
 
-In development a MongoDB instance will be started as a DevService. You can use an external instance with `-Dquarkus.mongodb.connection-string=mongodb://localhost:27017/`. Or forche the port number with `-Dquarkus.mongodb.devservices.port=27017`
+By default, ExploitIQ uses [Quarkus Dev Services](https://quarkus.io/guides/mongodb#dev-services) to start a MongoDB Testcontainer automatically in development mode. Sample reports are loaded at startup.
 
-At startup a bunch of reports will be loaded for development.
-
-In production it is expected that the following environment variables are provided:
-
-* `MONGODB_SVC_HOST`
-* `MONBODB_SVC_PORT`
-* `MONBODB_USERNAME`
-* `MONGODB_PASSWORD`
+To connect to an external MongoDB instance, refer to [Connecting to MongoDB](./connecting-to-mongodb.md).
 
 ## Queue and timeout
 

--- a/docs/connecting-to-mongodb.md
+++ b/docs/connecting-to-mongodb.md
@@ -1,0 +1,118 @@
+# Connecting to MongoDB
+
+This guide explains how to configure ExploitIQ to connect to an external MongoDB instance.
+
+## Prerequisites
+
+Before you configure ExploitIQ, ensure that the external MongoDB instance meets the following requirements:
+
+| Requirement | Value |
+| --- | --- |
+| MongoDB version | 8.x |
+| Database name | `exploit-iq-client` |
+| User role | `readWrite` on `exploit-iq-client` |
+| Auth source | `exploit-iq-client` |
+| Network access | ExploitIQ must be able to reach the MongoDB host and port |
+
+## Configuring the Application
+
+Set the following environment variables in your deployment. Use Mode A (host and port) or Mode B (MongoDB Atlas or SRV) — do not use both.
+
+### Mode A: Host and Port
+
+```text
+QUARKUS_MONGODB_HOSTS=<host>:<port>
+QUARKUS_MONGODB_DATABASE=exploit-iq-client
+QUARKUS_MONGODB_CREDENTIALS_USERNAME=<user>
+QUARKUS_MONGODB_CREDENTIALS_PASSWORD=<password>
+```
+
+The application uses `exploit-iq-client` as the default auth source. If your MongoDB user authenticates against a different database, for example `admin`, then set the following variable:
+
+```text
+QUARKUS_MONGODB_CREDENTIALS_AUTH_SOURCE=<auth-database>
+```
+
+### Mode B: MongoDB Atlas or SRV Connection String
+
+```text
+QUARKUS_MONGODB_CONNECTION_STRING=mongodb+srv://<user>:<password>@<cluster>/
+QUARKUS_MONGODB_DATABASE=exploit-iq-client
+```
+
+If your MongoDB user authenticates against a different database, then set the following variable:
+
+```text
+QUARKUS_MONGODB_CREDENTIALS_AUTH_SOURCE=<auth-database>
+```
+
+## Enabling TLS
+
+Use TLS when your MongoDB instance requires encrypted connections.
+
+To enable TLS with a standard trusted certificate authority, then set the following variable:
+
+```text
+QUARKUS_MONGODB_TLS=true
+```
+
+To use a custom certificate authority (CA) or self-signed certificate, set a named TLS configuration and mount the appropriate certificate into the application pod:
+
+```text
+QUARKUS_MONGODB_TLS=true
+QUARKUS_MONGODB_TLS_CONFIGURATION_NAME=<name>
+QUARKUS_TLS_<NAME>_TRUST_STORE_PEM_CERTS=<path-to-cert>
+```
+
+Refer to the [Quarkus TLS registry](https://quarkus.io/guides/tls-registry-reference) for how to define a named TLS configuration.
+
+## Verifying the Connection
+
+After you deploy the application, run the following commands to verify the connection:
+
+```bash
+# Confirm connection env vars are set
+oc exec deploy/exploit-iq-client -- env | grep -E 'QUARKUS_MONGODB|MONGODB'
+
+# Check MongoDB driver connection status
+oc logs deploy/exploit-iq-client | grep "Monitor thread successfully connected"
+```
+
+A successful connection produces a log line similar to the following:
+
+```text
+INFO [or.mo.dr.cluster] Monitor thread successfully connected to server with description ...}
+```
+
+## Development Mode
+
+By default, ExploitIQ uses [Quarkus Dev Services](https://quarkus.io/guides/mongodb#dev-services) to start a MongoDB Testcontainer automatically in development mode. To connect to an external MongoDB instance during development, use one of the following connection options.
+
+To connect to a local MongoDB instance, set the connection string when you start the application:
+
+```text
+./mvnw quarkus:dev -Dquarkus.mongodb.connection-string=mongodb://localhost:27017/
+```
+
+If your local MongoDB requires authentication, then include credentials in the connection string:
+
+```text
+./mvnw quarkus:dev -Dquarkus.mongodb.connection-string=mongodb://<user>:<password>@localhost:27017/exploit-iq-client?authSource=exploit-iq-client
+```
+
+To connect to MongoDB Atlas or any external MongoDB, disable Dev Services and set the connection string by using environment variables:
+
+```bash
+export QUARKUS_MONGODB_CONNECTION_STRING='mongodb+srv://<user>:<password>@<cluster>/'
+export QUARKUS_MONGODB_DATABASE='exploit-iq-client'
+
+./mvnw quarkus:dev -Dquarkus.mongodb.devservices.enabled=false
+```
+
+When you provide a connection string by either method, Dev Services does not start a Testcontainer.
+
+To force Dev Services to use a fixed port for the Testcontainer instead, use the following option:
+
+```text
+./mvnw quarkus:dev -Dquarkus.mongodb.devservices.port=27017
+```

--- a/docs/connecting-to-mongodb.md
+++ b/docs/connecting-to-mongodb.md
@@ -100,7 +100,7 @@ If your local MongoDB requires authentication, then include credentials in the c
 ./mvnw quarkus:dev -Dquarkus.mongodb.connection-string=mongodb://<user>:<password>@localhost:27017/exploit-iq-client?authSource=exploit-iq-client
 ```
 
-To connect to MongoDB Atlas or any external MongoDB, disable Dev Services and set the connection string by using environment variables:
+To connect to MongoDB Atlas or any external MongoDB, disable MongoDB Dev Services and set the connection string by using environment variables:
 
 ```bash
 export QUARKUS_MONGODB_CONNECTION_STRING='mongodb+srv://<user>:<password>@<cluster>/'

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,6 +20,8 @@ To see all the configuration options check the [configuration](./configuration.m
 
 For authentication setup (Keycloak, external identity providers, testing), see the [authentication](./authentication.md) guide.
 
+To connect the application to an external MongoDB instance, refer to [Connecting to MongoDB](./connecting-to-mongodb.md).
+
 ## Running the application in dev mode
 
 ### Integrated Mode (Default)


### PR DESCRIPTION
- Add `docs/connecting-to-mongodb.md`: customer-facing guide for connecting ExploitIQ to an external MongoDB instance
- Simplify `docs/configuration.md` MongoDB section to dev-only reference with a pointer to the new guide