### PR TITLE
chore: remove tech preview label from ui

### DIFF
--- a/src/main/webui/src/components/PageHeader.tsx
+++ b/src/main/webui/src/components/PageHeader.tsx
@@ -30,17 +30,10 @@ import {
   Flex,
   Stack,
   FlexItem,
-  Label,
-  Popover,
-  Content,
 } from '@patternfly/react-core';
 import { PageToggleButton } from '@patternfly/react-core';
 import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
-import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import UserAvatarDropdown from './UserAvatarDropdown';
-
-const TECH_PREVIEW_DISCLAIMER =
-  'This feature is currently available as a Technology Preview feature. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.';
 
 /**
  * Brand component - displays Red Hat logo and product name
@@ -117,33 +110,6 @@ const PageHeader: React.FC<PageHeaderProps> = ({ isSidebarOpen, onSidebarToggle 
     </Toolbar>
   );
 
-  const techPreviewTrigger = (
-    <Popover
-      triggerAction="click"
-      headerContent={<Title headingLevel="h6">Technology Preview</Title>}
-      bodyContent={
-        <Content component="p" className="pf-v6-u-mb-0">
-          {TECH_PREVIEW_DISCLAIMER}
-        </Content>
-      }
-      maxWidth="32rem"
-    >
-      <Label
-        color="blue"
-        icon={<InfoCircleIcon />}
-        isClickable
-        textMaxWidth="16ch"
-        render={({ className, content, componentRef }) => (
-          <button type="button" className={className} ref={componentRef}>
-            {content}
-          </button>
-        )}
-      >
-        Tech preview
-      </Label>
-    </Popover>
-  );
-
   return (
     <Masthead>
       <MastheadMain>
@@ -161,9 +127,6 @@ const PageHeader: React.FC<PageHeaderProps> = ({ isSidebarOpen, onSidebarToggle 
         <MastheadBrand aria-label="ExploitIQ">
           <Brand />
         </MastheadBrand>
-        <Flex alignItems={{ default: 'alignItemsCenter' }} className="pf-v6-u-ml-sm">
-          {techPreviewTrigger}
-        </Flex>
       </MastheadMain>
       <MastheadContent aria-label="Page header content">{headerToolbar}</MastheadContent>
     </Masthead>


### PR DESCRIPTION
According to the UX team- In GA level, no label is needed.
Remove the existing "Tech preview" label.

<img width="551" height="286" alt="image" src="https://github.com/user-attachments/assets/4a8fbdf8-7214-4eed-8e6c-7ddb9bbaf864" />

