### PR TITLE
chore: pin mongodb devservices image to 8.0.3-ubi8 for all profiles

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,6 +35,7 @@ quarkus.http.enable-compression=true
 
 quarkus.mongodb.database=${MONGODB_DATABASE:exploit-iq-client}
 quarkus.mongodb.credentials.auth-source=exploit-iq-client
+quarkus.mongodb.devservices.image-name=docker.io/mongodb/mongodb-community-server:8.0.3-ubi8
 %prod.quarkus.mongodb.hosts=${MONGODB_SVC_HOST}:${MONGODB_SVC_PORT}
 %prod.quarkus.mongodb.credentials.username=${MONGODB_USERNAME}
 %prod.quarkus.mongodb.credentials.password=${MONGODB_PASSWORD}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -9,7 +9,6 @@
 %test.quarkus.oidc.enabled=false
 %test.exploit-iq.credential-store.encryption-key=dev-test-key-must-be-32bytes-long!
 %test.quarkus.quinoa.enabled=false
-%test.quarkus.mongodb.devservices.image-name=docker.io/mongodb/mongodb-community-server:8.0.3-ubi8
 %test.quarkus.wiremock.devservices.reload=true
 %test.quarkus.wiremock.devservices.files-mapping=src/test/resources/devservices/wiremock
 # WireMock dev service logs full request/response bodies at INFO; raise level to avoid huge test logs.


### PR DESCRIPTION
Fixes an incomplete change from #248, which pinned the MongoDB DevServices image to `docker.io/mongodb/mongodb-community-server:8.0.3-ubi8` only for the `%test` profile. 
The current changes apply to all profiles by default.
