### PR TITLE
fix: date completed displays the same timestamp as date requested on failed SBOM

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportRepositoryService.java
@@ -697,6 +697,8 @@ public class ReportRepositoryService {
       }
     }
 
+    var metadata = extractMetadata(doc);
+
     if (doc.containsKey("error")) {
       var error = doc.get("error", Document.class);
       if (Objects.nonNull(error)) {
@@ -705,7 +707,6 @@ public class ReportRepositoryService {
           return errorAt;
         }
       }
-      var metadata = extractMetadata(doc);
       if (Objects.nonNull(scan)) {
         String startedAt = scan.getString("started_at");
         if (Objects.nonNull(startedAt) && !startedAt.isBlank()) {
@@ -719,7 +720,6 @@ public class ReportRepositoryService {
       return null;
     }
 
-    var metadata = extractMetadata(doc);
     return metadata.get(SUBMITTED_AT);
   }
 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportRepositoryService.java
@@ -342,7 +342,9 @@ public class ReportRepositoryService {
 
   public void updateWithError(String id, String errorType, String errorMessage) {
     String productId = getProductId(id);
-    var error = new Document("type", errorType).append("message", errorMessage);
+    var error = new Document("type", errorType)
+        .append("message", errorMessage)
+        .append("at", Instant.now().toString());
     getCollection().updateOne(new Document(RepositoryConstants.ID_KEY, new ObjectId(id)), Updates.set("error", error));
     if (Objects.nonNull(productId)) {
       checkAndStoreProductCompletion(productId);
@@ -640,9 +642,18 @@ public class ReportRepositoryService {
   }
 
   private void checkAndStoreProductCompletion(String productId) {
-    // Check if this product just became completed
+    String latestCompletionTime = computeLatestCompletionTimeForProduct(productId);
+    if (Objects.nonNull(latestCompletionTime)) {
+      productRepositoryService.updateCompletedAtWithoutCatalogNotification(productId, latestCompletionTime);
+      LOGGER.infof("Product %s completed at %s", productId, latestCompletionTime);
+    }
+  }
+
+  /**
+   * Latest terminal completion time across all reports for a product, or {@code null} while any report is still in progress.
+   */
+  public String computeLatestCompletionTimeForProduct(String productId) {
     Bson productFilter = Filters.eq("metadata." + PRODUCT_ID, productId);
-    boolean hasCompletionTimeStored = false;
     boolean hasPendingReports = false;
     String latestCompletionTime = null;
 
@@ -650,49 +661,66 @@ public class ReportRepositoryService {
       while (cursor.hasNext()) {
         Document doc = cursor.next();
         Map<String, String> metadata = extractMetadata(doc);
-        
-        if (Objects.nonNull(metadata.get("product_completed_at"))) {
-          hasCompletionTimeStored = true;
-          break;
-        }
-        
         String reportStatus = getStatus(doc, metadata);
-        
+
         if ("pending".equals(reportStatus) || "queued".equals(reportStatus) || "sent".equals(reportStatus)) {
           hasPendingReports = true;
           break;
         }
-        
+
         if ("completed".equals(reportStatus) || "failed".equals(reportStatus) || "expired".equals(reportStatus)) {
           String completedAt = getReportCompletionTime(doc);
-          if (Objects.nonNull(completedAt) && (Objects.isNull(latestCompletionTime) || completedAt.compareTo(latestCompletionTime) > 0)) {
+          if (Objects.nonNull(completedAt)
+              && (Objects.isNull(latestCompletionTime) || completedAt.compareTo(latestCompletionTime) > 0)) {
             latestCompletionTime = completedAt;
           }
         }
       }
     }
 
-    if (!hasCompletionTimeStored && !hasPendingReports && Objects.nonNull(latestCompletionTime)) {
-      productRepositoryService.updateCompletedAtWithoutCatalogNotification(productId, latestCompletionTime);
-      LOGGER.infof("Product %s completed at %s", productId, latestCompletionTime);
-    }
+    return hasPendingReports ? null : latestCompletionTime;
   }
 
-  private String getReportCompletionTime(Document doc) {
+  /**
+   * Package-private for unit tests.
+   */
+  String getReportCompletionTime(Document doc) {
+    Document scan = null;
     var input = doc.get("input", Document.class);
     if (Objects.nonNull(input)) {
-      var scan = input.get("scan", Document.class);
+      scan = input.get("scan", Document.class);
       if (Objects.nonNull(scan)) {
         String completedAt = scan.getString("completed_at");
-        if (Objects.nonNull(completedAt)) {
+        if (Objects.nonNull(completedAt) && !completedAt.isBlank()) {
           return completedAt;
         }
       }
     }
-    
+
+    if (doc.containsKey("error")) {
+      var error = doc.get("error", Document.class);
+      if (Objects.nonNull(error)) {
+        String errorAt = error.getString("at");
+        if (Objects.nonNull(errorAt) && !errorAt.isBlank()) {
+          return errorAt;
+        }
+      }
+      var metadata = extractMetadata(doc);
+      if (Objects.nonNull(scan)) {
+        String startedAt = scan.getString("started_at");
+        if (Objects.nonNull(startedAt) && !startedAt.isBlank()) {
+          return startedAt;
+        }
+      }
+      String sentAt = metadata.get(SENT_AT);
+      if (Objects.nonNull(sentAt)) {
+        return sentAt;
+      }
+      return null;
+    }
+
     var metadata = extractMetadata(doc);
-    String submittedAt = metadata.get("submitted_at");
-    return submittedAt;
+    return metadata.get(SUBMITTED_AT);
   }
 
   public boolean remove(String id) {

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/OverviewMetricsService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/OverviewMetricsService.java
@@ -63,7 +63,8 @@ public class OverviewMetricsService {
     private Bson getCompletedReportsFromLastWeekFilter(String oneWeekAgoIsoString) {
         return Filters.and(
             Filters.ne("input.scan.completed_at", null),
-            Filters.gte("input.scan.completed_at", oneWeekAgoIsoString)
+            Filters.gte("input.scan.completed_at", oneWeekAgoIsoString),
+            Filters.exists("error", false)
         );
     }
 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
@@ -189,7 +189,9 @@ public class ReportService {
     List<ProductSummary> summaries = new ArrayList<>();
     for (Product product : listResult.products()) {
       ProductReportsSummary productReportsSummary = repository.getProductSummaryData(product);
-      summaries.add(new ProductSummary(product, productReportsSummary));
+      summaries.add(new ProductSummary(
+          withResolvedCompletedAt(product, productReportsSummary),
+          productReportsSummary));
     }
     
     return new ProductSummariesResult(summaries, listResult.totalCount());
@@ -202,11 +204,36 @@ public class ReportService {
     }
 
     ProductReportsSummary productReportsSummary = repository.getProductSummaryData(product);
-    
+
     return new ProductSummary(
-      product, 
+      withResolvedCompletedAt(product, productReportsSummary),
       productReportsSummary
     );
+  }
+
+  /**
+   * Recomputes product completion time from terminal report timestamps so failed analyses
+   * do not surface {@code submitted_at} as the completion date.
+   */
+  private Product withResolvedCompletedAt(Product product, ProductReportsSummary summary) {
+    if (!"completed".equals(summary.productState())) {
+      return product;
+    }
+    String computedCompletedAt = repository.computeLatestCompletionTimeForProduct(product.id());
+    if (Objects.isNull(computedCompletedAt) || computedCompletedAt.equals(product.completedAt())) {
+      return product;
+    }
+    productRepository.updateCompletedAtWithoutCatalogNotification(product.id(), computedCompletedAt);
+    return new Product(
+        product.id(),
+        product.name(),
+        product.version(),
+        product.submittedAt(),
+        product.submittedCount(),
+        product.metadata(),
+        product.submissionFailures(),
+        computedCompletedAt,
+        product.cveId());
   }
 
   public List<String> getReportIds(List<String> productIds) {

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportRepositoryServiceTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportRepositoryServiceTest.java
@@ -5,11 +5,17 @@
 
 package com.redhat.ecosystemappeng.exploitiq.repository;
 
+import java.time.Instant;
+import java.util.Date;
+
+import org.bson.Document;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/** Unit coverage for RPM package substring filter literals (Mongo {@code $regexMatch} input). */
+/** Unit coverage for RPM package substring filter literals and report completion timestamps. */
 class ReportRepositoryServiceTest {
+
+    private final ReportRepositoryService repository = new ReportRepositoryService();
 
     @Test
     void rpmPackageMatchRegexLiteral_quotesDotsAndHyphensForLiteralSubstring() {
@@ -22,5 +28,74 @@ class ReportRepositoryServiceTest {
     void rpmPackageMatchRegexLiteral_caseFoldsAscii() {
         Assertions.assertEquals(ReportRepositoryService.rpmPackageMatchRegexLiteral("LibArchive"),
                 ReportRepositoryService.rpmPackageMatchRegexLiteral("libarchive"));
+    }
+
+    @Test
+    void getReportCompletionTime_failedReportPrefersErrorAtOverSubmittedAt() {
+        Document doc = failedReportDocument(
+            "2026-04-02T12:00:00Z",
+            "2026-04-02T11:00:00.000000",
+            "2026-04-02T10:00:00Z",
+            "2026-04-02T10:01:00Z");
+
+        Assertions.assertEquals("2026-04-02T12:00:00Z", repository.getReportCompletionTime(doc));
+    }
+
+    @Test
+    void getReportCompletionTime_failedReportWithoutErrorAtUsesStartedAtNotSubmittedAt() {
+        Document doc = failedReportDocument(
+            null,
+            "2026-04-02T11:00:00.000000",
+            "2026-04-02T10:00:00Z",
+            "2026-04-02T10:01:00Z");
+
+        Assertions.assertEquals("2026-04-02T11:00:00.000000", repository.getReportCompletionTime(doc));
+    }
+
+    @Test
+    void getReportCompletionTime_failedReportWithoutStartedAtUsesSentAtNotSubmittedAt() {
+        Document doc = failedReportDocument(
+            null,
+            null,
+            "2026-04-02T10:00:00Z",
+            "2026-04-02T10:01:00Z");
+
+        Assertions.assertEquals("2026-04-02T10:01:00Z", repository.getReportCompletionTime(doc));
+    }
+
+    @Test
+    void getReportCompletionTime_failedReportWithoutTimestampsDoesNotFallBackToSubmittedAt() {
+        Document doc = failedReportDocument(
+            null,
+            null,
+            "2026-04-02T10:00:00Z",
+            null);
+
+        Assertions.assertNull(repository.getReportCompletionTime(doc));
+    }
+
+    private static Document failedReportDocument(
+            String errorAt,
+            String startedAt,
+            String submittedAt,
+            String sentAt) {
+        Document error = new Document("type", "failed").append("message", "analysis failed");
+        if (errorAt != null) {
+            error.append("at", errorAt);
+        }
+
+        Document scan = new Document();
+        if (startedAt != null) {
+            scan.append("started_at", startedAt);
+        }
+
+        Document metadata = new Document("submitted_at", Date.from(Instant.parse(submittedAt)));
+        if (sentAt != null) {
+            metadata.append("sent_at", Date.from(Instant.parse(sentAt)));
+        }
+
+        return new Document("error", error)
+            .append("input", new Document("scan", scan))
+            .append("metadata", metadata);
     }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where the SBOM table showed **Date Completed** identical to **Date Requested** for products with a **Failed** finding, even when analysis ran for a long time before reaching a terminal state.

The root cause was in `ReportRepositoryService.getReportCompletionTime()`: when a failed report had no `input.scan.completed_at`, the code fell back to `metadata.submitted_at` and persisted that as the product's `completedAt`.

## Changes

- **Record failure timestamp** — `updateWithError()` now stores `error.at` when an analysis fails.
- **Correct completion-time resolution** — For failed/expired reports, completion time is resolved from (in order): `input.scan.completed_at`, `error.at`, `input.scan.started_at`, `metadata.sent_at`. `submitted_at` is no longer used as a fallback for failed reports.
- **Backfill on read** — `ReportService.withResolvedCompletedAt()` recomputes and persists the correct `completedAt` when serving product summaries, fixing existing bad data on the next SBOM table load.
- **Home page metrics** — `OverviewMetricsService` excludes reports with an `error` field so failed analyses are not counted in the last-7-days metrics (only truly completed reports are included).

[Resolves ](https://redhat.atlassian.net/issues?filter=106533&selectedIssue=TC-5173)