### PR TITLE
fix: disable OTLP exporter by default

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -171,8 +171,7 @@ quarkus.management.proxy.paths=/health,/health-ui,/metrics,/info
 #  /reports/.*+=/reports/{id}
 quarkus.micrometer.binder.http-server.ignore-patterns=^(?!/reports).*$
 
-#quarkus.otel.exporter.otlp.enabled=false
-#quarkus.opentelemetry.tracer.exporter.otlp.enabled=false
+quarkus.otel.exporter.otlp.enabled=false
 quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n
 
 # SSE keepalive interval; must be lower than ingress/proxy idle timeout to prevent stream disconnects


### PR DESCRIPTION
- Disable OTLP exporter by default to eliminate `Connection refused: localhost/127.0.0.1:4317` warnings when no OTel collector is present
- OTel SDK remains enabled so traceIds are still generated and available in logs
- Collector-enabled environments (mlops, tests) override via `QUARKUS_OTEL_EXPORTER_OTLP_ENABLED=true`