### PR TITLE
feat: add audit trail for report deletion and modification operations

### DIFF
--- a/openspec/specs/report-audit-trail/spec.md
+++ b/openspec/specs/report-audit-trail/spec.md
@@ -5,7 +5,7 @@ TBD - created by archiving change add-report-deletion-audit-trail. Update Purpos
 ## Requirements
 ### Requirement: Append-only report audit collection
 
-The backend SHALL persist report destructive-operation audit records in a dedicated MongoDB collection named `report_audit_trail`. Collection initialization SHALL follow the existing repository pattern: indexes are created at application startup via `@PostConstruct` using idempotent `createIndex` calls. The repository layer SHALL expose **insert only**; no update, delete, or REST endpoints SHALL mutate or remove audit documents.
+The backend SHALL persist report destructive-operation audit records in a dedicated MongoDB collection named `report_audit_trail`. Collection initialization SHALL follow the existing repository pattern: indexes are created at application startup via `@PostConstruct` using idempotent `createIndex` calls. The repository layer SHALL NOT expose generic update or delete APIs. The only permitted mutation of an audit document is setting `deleted` from `false` to `true` after the corresponding report removal succeeds, via `ReportAuditService.deleteSucceeded`.
 
 Each audit document SHALL contain:
 
@@ -14,18 +14,21 @@ Each audit document SHALL contain:
 - `operation` — one of `DELETE_SINGLE`, `DELETE_BULK`, `DELETE_BULK_FILTER`, `DELETE_BY_PRODUCT`, `DELETE_BY_PRODUCTS`, `MODIFY_STATUS`, `DELETE_PURGE`
 - `report_ids` — array of affected report MongoDB ObjectId hex strings
 - `context` (optional) — operation-specific metadata such as query filters, product IDs, scan ID, error type/message, or purge threshold
+- `deleted` — `false` when the audit intent is recorded; `true` only after report removal succeeds
 
 #### Scenario: Collection initialized at startup
 
 - **WHEN** the application starts
 - **THEN** `ReportAuditRepositoryService` initializes indexes on `report_audit_trail`
-- **AND** the repository exposes no update or delete methods
+- **AND** the repository does not expose generic update or delete methods
 
-#### Scenario: Audit record inserted before mutation
+#### Scenario: Audit intent recorded before deletion, confirmed after success
 
-- **WHEN** a destructive report operation is initiated through `ReportService`
-- **THEN** an audit document is inserted into `report_audit_trail` before the report delete or status update is applied
+- **WHEN** a report deletion is initiated through `ReportService`
+- **THEN** an audit document is inserted into `report_audit_trail` with `deleted=false` before the report delete is applied
 - **AND** if audit insertion fails, the destructive operation SHALL NOT proceed
+- **AND** when report removal succeeds, `deleted` is updated to `true` via `deleteSucceeded`
+- **AND** when report removal fails, the audit document remains with `deleted=false`
 
 ### Requirement: Authenticated actor on REST destructive operations
 

--- a/openspec/specs/report-audit-trail/spec.md
+++ b/openspec/specs/report-audit-trail/spec.md
@@ -1,0 +1,108 @@
+# report-audit-trail Specification
+
+## Purpose
+TBD - created by archiving change add-report-deletion-audit-trail. Update Purpose after archive.
+## Requirements
+### Requirement: Append-only report audit collection
+
+The backend SHALL persist report destructive-operation audit records in a dedicated MongoDB collection named `report_audit_trail`. Collection initialization SHALL follow the existing repository pattern: indexes are created at application startup via `@PostConstruct` using idempotent `createIndex` calls. The repository layer SHALL expose **insert only**; no update, delete, or REST endpoints SHALL mutate or remove audit documents.
+
+Each audit document SHALL contain:
+
+- `actor` — authenticated user identifier, service principal name, or `system:purge` for scheduled purge
+- `timestamp` — server time when the audit record was created
+- `operation` — one of `DELETE_SINGLE`, `DELETE_BULK`, `DELETE_BULK_FILTER`, `DELETE_BY_PRODUCT`, `DELETE_BY_PRODUCTS`, `MODIFY_STATUS`, `DELETE_PURGE`
+- `report_ids` — array of affected report MongoDB ObjectId hex strings
+- `context` (optional) — operation-specific metadata such as query filters, product IDs, scan ID, error type/message, or purge threshold
+
+#### Scenario: Collection initialized at startup
+
+- **WHEN** the application starts
+- **THEN** `ReportAuditRepositoryService` initializes indexes on `report_audit_trail`
+- **AND** the repository exposes no update or delete methods
+
+#### Scenario: Audit record inserted before mutation
+
+- **WHEN** a destructive report operation is initiated through `ReportService`
+- **THEN** an audit document is inserted into `report_audit_trail` before the report delete or status update is applied
+- **AND** if audit insertion fails, the destructive operation SHALL NOT proceed
+
+### Requirement: Authenticated actor on REST destructive operations
+
+All destructive `ReportEndpoint` handlers (`DELETE /reports/{id}`, `DELETE /reports`, `DELETE /reports/product/{id}`, `DELETE /reports/product`, `POST /reports/failed`) SHALL resolve the caller identity using `SecurityContext` and `UtilitiesService.getAuthenticatedUserName` with `UserService`. The resolved actor SHALL be passed to `ReportService` and stored on the audit record. If no actor can be resolved, the endpoint SHALL return **401 Unauthorized** and SHALL NOT mutate report data.
+
+#### Scenario: Single report delete records authenticated actor
+
+- **WHEN** an authenticated client calls `DELETE /api/v1/reports/{id}`
+- **THEN** the backend resolves the caller identity from the security context
+- **AND** writes an audit record with operation `DELETE_SINGLE` and `report_ids` containing `{id}`
+- **AND** proceeds with report deletion
+
+#### Scenario: Bulk delete by report IDs records authenticated actor
+
+- **WHEN** an authenticated client calls `DELETE /api/v1/reports?reportIds=id1&reportIds=id2`
+- **THEN** the backend writes an audit record with operation `DELETE_BULK` and the requested report IDs
+- **AND** proceeds with deletion of those reports
+
+#### Scenario: Bulk delete by filter records filter context
+
+- **WHEN** an authenticated client calls `DELETE /api/v1/reports` with query parameters that are not fixed pagination/sort params and without `reportIds`
+- **THEN** the backend resolves all matching report IDs before deletion
+- **AND** writes an audit record with operation `DELETE_BULK_FILTER`, `report_ids` set to all matches, and `context.filter` capturing the filter map
+- **AND** proceeds with deletion of matching reports
+
+#### Scenario: Product-scoped delete records product context
+
+- **WHEN** an authenticated client calls `DELETE /api/v1/reports/product/{id}` or `DELETE /api/v1/reports/product?productIds=...`
+- **THEN** the backend resolves report IDs for the product(s)
+- **AND** writes an audit record with operation `DELETE_BY_PRODUCT` or `DELETE_BY_PRODUCTS`, the resolved `report_ids`, and `context.product_ids`
+- **AND** proceeds with report deletion (and existing product metadata removal)
+
+#### Scenario: Unauthenticated destructive request rejected
+
+- **WHEN** a client calls a destructive report endpoint without a resolvable authenticated actor
+- **THEN** the backend returns **401 Unauthorized**
+- **AND** no report data is deleted or modified
+- **AND** no audit record is written
+
+### Requirement: Owner verification for mark failed by scan ID
+
+`POST /api/v1/reports/failed` (`markFailedByScanId`) SHALL verify ownership before updating report status. For human users (actor resolved via `UserService` without a JWT principal name), every report matching the scan ID SHALL have `metadata.user` equal to the actor. For service accounts (JWT principal name present per `UtilitiesService`), owner verification SHALL be skipped. On success, the backend SHALL write an audit record with operation `MODIFY_STATUS`, affected `report_ids`, and `context` containing `scanId`, `errorType`, and `errorMessage`.
+
+#### Scenario: Human user marks own report failed
+
+- **WHEN** an authenticated human user calls `POST /api/v1/reports/failed` for a scan ID whose reports all have `metadata.user` matching the caller
+- **THEN** the backend writes a `MODIFY_STATUS` audit record
+- **AND** updates the reports with the provided error type and message
+- **AND** returns **202 Accepted**
+
+#### Scenario: Human user denied for another user's report
+
+- **WHEN** an authenticated human user calls `POST /api/v1/reports/failed` for a scan ID where any matching report has `metadata.user` different from the caller or missing
+- **THEN** the backend returns **403 Forbidden**
+- **AND** does not modify any report
+- **AND** does not write an audit record
+
+#### Scenario: Service account may mark any matching report failed
+
+- **WHEN** an authenticated service account (JWT principal name present) calls `POST /api/v1/reports/failed` for an existing scan ID
+- **THEN** the backend writes a `MODIFY_STATUS` audit record with the service principal as `actor`
+- **AND** updates all matching reports
+- **AND** returns **202 Accepted**
+
+### Requirement: Scheduled purge audit trail
+
+When the configured purge cron job removes reports via `removeBefore`, the backend SHALL write an audit record with actor `system:purge`, operation `DELETE_PURGE`, `report_ids` listing all deleted report IDs, and `context` containing the purge threshold timestamp.
+
+#### Scenario: Purge job records deleted report IDs
+
+- **WHEN** the scheduled purge job deletes one or more reports older than the configured threshold
+- **THEN** the backend writes a `DELETE_PURGE` audit record with actor `system:purge`
+- **AND** `report_ids` contains every deleted report ID
+- **AND** `context` includes the threshold instant used for the purge
+
+#### Scenario: Purge with zero deletions writes no audit
+
+- **WHEN** the scheduled purge job runs and no reports match the threshold
+- **THEN** no audit record is written
+

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/model/ReportAuditLog.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/model/ReportAuditLog.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.model;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record ReportAuditLog(
+        String actor,
+        Instant timestamp,
+        ReportAuditOperation operation,
+        List<String> reportIds,
+        Map<String, Object> context) {
+}

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/model/ReportAuditLog.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/model/ReportAuditLog.java
@@ -18,10 +18,16 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Audit intent for a destructive report operation.
+ * {@code deleted} starts {@code false} on insert and is set to {@code true} only after
+ * the corresponding report removal succeeds.
+ */
 public record ReportAuditLog(
         String actor,
         Instant timestamp,
         ReportAuditOperation operation,
         List<String> reportIds,
-        Map<String, Object> context) {
+        Map<String, Object> context,
+        boolean deleted) {
 }

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/model/ReportAuditOperation.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/model/ReportAuditOperation.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.model;
+
+public enum ReportAuditOperation {
+    DELETE_SINGLE,
+    DELETE_BULK,
+    DELETE_BULK_FILTER,
+    DELETE_BY_PRODUCT,
+    DELETE_BY_PRODUCTS,
+    MODIFY_STATUS,
+    DELETE_PURGE
+}

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportAuditRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportAuditRepositoryService.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.repository;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.Sorts;
+import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditLog;
+import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditOperation;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.bson.Document;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@ApplicationScoped
+@RegisterForReflection(targets = { Document.class })
+public class ReportAuditRepositoryService {
+
+    private static final Logger LOGGER = Logger.getLogger(ReportAuditRepositoryService.class);
+    static final String COLLECTION_NAME = "report_audit_trail";
+    private static final String ACTOR_FIELD = "actor";
+    private static final String TIMESTAMP_FIELD = "timestamp";
+    private static final String OPERATION_FIELD = "operation";
+    private static final String REPORT_IDS_FIELD = "report_ids";
+    private static final String CONTEXT_FIELD = "context";
+
+    @Inject
+    MongoClient mongoClient;
+
+    @ConfigProperty(name = "quarkus.mongodb.database")
+    String dbName;
+
+    @PostConstruct
+    public void dbInit() {
+        MongoCollection<Document> collection = getCollection();
+        collection.createIndex(Indexes.descending(TIMESTAMP_FIELD));
+        collection.createIndex(Indexes.compoundIndex(
+                Indexes.ascending(ACTOR_FIELD),
+                Indexes.descending(TIMESTAMP_FIELD)));
+        collection.createIndex(Indexes.ascending(REPORT_IDS_FIELD));
+        LOGGER.info("Report audit trail collection initialized with indexes");
+    }
+
+    public void insert(ReportAuditLog record) {
+        Document doc = new Document()
+                .append(ACTOR_FIELD, record.actor())
+                .append(TIMESTAMP_FIELD, Date.from(record.timestamp()))
+                .append(OPERATION_FIELD, record.operation().name())
+                .append(REPORT_IDS_FIELD, record.reportIds());
+        if (Objects.nonNull(record.context()) && !record.context().isEmpty()) {
+            doc.append(CONTEXT_FIELD, new Document(record.context()));
+        }
+        getCollection().insertOne(doc);
+    }
+
+    public long countDocuments() {
+        return getCollection().countDocuments();
+    }
+
+    public Document findLatestByOperation(ReportAuditOperation operation) {
+        return getCollection()
+                .find(new Document(OPERATION_FIELD, operation.name()))
+                .sort(Sorts.descending(TIMESTAMP_FIELD))
+                .first();
+    }
+
+    MongoCollection<Document> getCollection() {
+        return mongoClient.getDatabase(dbName).getCollection(COLLECTION_NAME);
+    }
+}

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportAuditRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportAuditRepositoryService.java
@@ -16,9 +16,10 @@ package com.redhat.ecosystemappeng.exploitiq.repository;
 
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
-import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Indexes;
 import com.mongodb.client.model.Sorts;
+import com.mongodb.client.model.Updates;
 import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditLog;
 import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditOperation;
 import io.quarkus.runtime.annotations.RegisterForReflection;
@@ -29,10 +30,8 @@ import org.bson.Document;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
-import java.time.Instant;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 @ApplicationScoped
@@ -46,6 +45,7 @@ public class ReportAuditRepositoryService {
     private static final String OPERATION_FIELD = "operation";
     private static final String REPORT_IDS_FIELD = "report_ids";
     private static final String CONTEXT_FIELD = "context";
+    private static final String DELETED_FIELD = "deleted";
 
     @Inject
     MongoClient mongoClient;
@@ -61,6 +61,9 @@ public class ReportAuditRepositoryService {
                 Indexes.ascending(ACTOR_FIELD),
                 Indexes.descending(TIMESTAMP_FIELD)));
         collection.createIndex(Indexes.ascending(REPORT_IDS_FIELD));
+        collection.createIndex(Indexes.compoundIndex(
+                Indexes.ascending(DELETED_FIELD),
+                Indexes.ascending(REPORT_IDS_FIELD)));
         LOGGER.info("Report audit trail collection initialized with indexes");
     }
 
@@ -69,11 +72,37 @@ public class ReportAuditRepositoryService {
                 .append(ACTOR_FIELD, record.actor())
                 .append(TIMESTAMP_FIELD, Date.from(record.timestamp()))
                 .append(OPERATION_FIELD, record.operation().name())
-                .append(REPORT_IDS_FIELD, record.reportIds());
+                .append(REPORT_IDS_FIELD, record.reportIds())
+                .append(DELETED_FIELD, record.deleted());
         if (Objects.nonNull(record.context()) && !record.context().isEmpty()) {
             doc.append(CONTEXT_FIELD, new Document(record.context()));
         }
         getCollection().insertOne(doc);
+    }
+
+    /**
+     * Confirms deletion for the most recent pending audit whose {@code report_ids} match.
+     * The only allowed update is setting {@code deleted} from {@code false} to {@code true}.
+     *
+     * @return {@code true} when a pending audit document was updated
+     */
+    public boolean markDeletedTrue(List<String> reportIds) {
+        Document pending = getCollection()
+                .find(Filters.and(
+                        Filters.eq(DELETED_FIELD, false),
+                        Filters.eq(REPORT_IDS_FIELD, reportIds)))
+                .sort(Sorts.descending(TIMESTAMP_FIELD))
+                .first();
+        if (Objects.isNull(pending)) {
+            return false;
+        }
+        return getCollection()
+                .updateOne(
+                        Filters.and(
+                                Filters.eq("_id", pending.getObjectId("_id")),
+                                Filters.eq(DELETED_FIELD, false)),
+                        Updates.set(DELETED_FIELD, true))
+                .getModifiedCount() == 1;
     }
 
     public long countDocuments() {

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportRepositoryService.java
@@ -778,12 +778,36 @@ public class ReportRepositoryService {
     return collection;
   }
 
-  public void removeBefore(Instant threshold) {
-    var count = getCollection().deleteMany(Filters.lt("metadata." + SUBMITTED_AT, threshold)).getDeletedCount();
+  public List<String> findIdsByFilter(Map<String, String> queryFilter) {
+    var filter = buildQueryFilter(queryFilter);
+    List<String> ids = new ArrayList<>();
+    try (MongoCursor<Document> docs = getCollection().find(filter).cursor()) {
+      while (docs.hasNext()) {
+        Document doc = docs.next();
+        ids.add(doc.get(RepositoryConstants.ID_KEY, ObjectId.class).toHexString());
+      }
+    }
+    return ids;
+  }
+
+  public List<String> removeBefore(Instant threshold) {
+    var filter = Filters.lt("metadata." + SUBMITTED_AT, threshold);
+    List<String> deletedIds = new ArrayList<>();
+    try (MongoCursor<Document> docs = getCollection().find(filter).cursor()) {
+      while (docs.hasNext()) {
+        Document doc = docs.next();
+        deletedIds.add(doc.get(RepositoryConstants.ID_KEY, ObjectId.class).toHexString());
+      }
+    }
+    if (deletedIds.isEmpty()) {
+      return deletedIds;
+    }
+    long count = getCollection().deleteMany(filter).getDeletedCount();
     LOGGER.debugf("Removed %s reports before %s", count, threshold);
     if (count > 0) {
       reportSseBroadcaster.publishCatalogChanged();
     }
+    return deletedIds;
   }
 
   private void handleMultipleValues(String valueString, 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportRepositoryService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportRepositoryService.java
@@ -790,24 +790,25 @@ public class ReportRepositoryService {
     return ids;
   }
 
-  public List<String> removeBefore(Instant threshold) {
+  public List<String> findIdsSubmittedBefore(Instant threshold) {
     var filter = Filters.lt("metadata." + SUBMITTED_AT, threshold);
-    List<String> deletedIds = new ArrayList<>();
+    List<String> ids = new ArrayList<>();
     try (MongoCursor<Document> docs = getCollection().find(filter).cursor()) {
       while (docs.hasNext()) {
         Document doc = docs.next();
-        deletedIds.add(doc.get(RepositoryConstants.ID_KEY, ObjectId.class).toHexString());
+        ids.add(doc.get(RepositoryConstants.ID_KEY, ObjectId.class).toHexString());
       }
     }
-    if (deletedIds.isEmpty()) {
-      return deletedIds;
-    }
+    return ids;
+  }
+
+  public void removeBefore(Instant threshold) {
+    var filter = Filters.lt("metadata." + SUBMITTED_AT, threshold);
     long count = getCollection().deleteMany(filter).getDeletedCount();
     LOGGER.debugf("Removed %s reports before %s", count, threshold);
     if (count > 0) {
       reportSseBroadcaster.publishCatalogChanged();
     }
-    return deletedIds;
   }
 
   private void handleMultipleValues(String valueString, 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpoint.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -56,16 +57,19 @@ import com.redhat.ecosystemappeng.exploitiq.service.RpmReportService;
 import com.redhat.ecosystemappeng.exploitiq.service.RequestQueueExceededException;
 import com.redhat.ecosystemappeng.exploitiq.service.UserService;
 import com.redhat.ecosystemappeng.exploitiq.service.UtilitiesService;
+import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditOperation;
 import com.redhat.ecosystemappeng.exploitiq.model.Report;
 import com.redhat.ecosystemappeng.exploitiq.model.ReportRequestId;
 import com.redhat.ecosystemappeng.exploitiq.model.ReportWithStatus;
 import com.redhat.ecosystemappeng.exploitiq.model.ProductSummary;
 
+import io.quarkus.security.ForbiddenException;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -734,6 +738,14 @@ public class ReportEndpoint {
       description = "No report found for the given scan ID"
     ),
     @APIResponse(
+      responseCode = "401",
+      description = "Authentication required"
+    ),
+    @APIResponse(
+      responseCode = "403",
+      description = "Caller is not authorized to modify the report"
+    ),
+    @APIResponse(
       responseCode = "500",
       description = "Internal server error"
     )
@@ -745,7 +757,9 @@ public class ReportEndpoint {
       content = @Content(schema = @Schema(implementation = MarkReportFailedRequest.class))
     )
     MarkReportFailedRequest body) {
-    reportService.markFailedByScanId(body.scanId(), body.errorType(), body.errorMessage());
+    String actor = requireActor();
+    reportService.markFailedByScanId(
+        body.scanId(), body.errorType(), body.errorMessage(), actor, securityContext);
     return Response.accepted(body.scanId()).build();
   }
 
@@ -760,6 +774,10 @@ public class ReportEndpoint {
       description = "Report deletion request accepted"
     ),
     @APIResponse(
+      responseCode = "401",
+      description = "Authentication required"
+    ),
+    @APIResponse(
       responseCode = "500", 
       description = "Internal server error"
     )
@@ -770,7 +788,8 @@ public class ReportEndpoint {
       required = true
     )
     @PathParam("id") String id) {
-    if (reportService.remove(id)) {
+    String actor = requireActor();
+    if (reportService.remove(actor, id)) {
       return Response.accepted().build();
     }
     return Response.serverError().build();
@@ -786,6 +805,10 @@ public class ReportEndpoint {
       description = "Reports deletion request accepted"
     ),
     @APIResponse(
+      responseCode = "401",
+      description = "Authentication required"
+    ),
+    @APIResponse(
       responseCode = "500", 
       description = "Internal server error"
     )
@@ -796,13 +819,14 @@ public class ReportEndpoint {
     )
     @QueryParam("reportIds") List<String> reportIds, 
     @Context UriInfo uriInfo) {
+    String actor = requireActor();
     if (reportIds.isEmpty()) {
       var filter = uriInfo.getQueryParameters().entrySet().stream()
           .filter(e -> !FIXED_QUERY_PARAMS.contains(e.getKey()))
           .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().getFirst()));
-      reportService.remove(filter);
+      reportService.remove(actor, filter);
     } else {
-      reportService.remove(reportIds);
+      reportService.remove(actor, reportIds);
     }
     return Response.accepted().build();
   }
@@ -842,7 +866,12 @@ public class ReportEndpoint {
     if (Objects.isNull(reportIds) || reportIds.isEmpty()) {
       return Response.accepted().build();
     }
-    reportService.remove(reportIds);
+    String actor = requireActor();
+    reportService.remove(
+        actor,
+        ReportAuditOperation.DELETE_BY_PRODUCTS,
+        reportIds,
+        Map.of("product_ids", productIds));
     productService.remove(productIds);
     return Response.accepted().build();
   }
@@ -872,9 +901,22 @@ public class ReportEndpoint {
     if (Objects.isNull(reportIds) || reportIds.isEmpty()) {
       return Response.accepted().build();
     }
-    reportService.remove(reportIds);
+    String actor = requireActor();
+    reportService.remove(
+        actor,
+        ReportAuditOperation.DELETE_BY_PRODUCT,
+        reportIds,
+        Map.of("product_ids", List.of(id)));
     productService.remove(id);
     return Response.accepted().build();
+  }
+
+  private String requireActor() {
+    String actor = UtilitiesService.getAuthenticatedUserName(securityContext, userService);
+    if (Objects.isNull(actor) || actor.isBlank()) {
+      throw new NotAuthorizedException("Authentication required");
+    }
+    return actor;
   }
 
   /**
@@ -913,6 +955,22 @@ public class ReportEndpoint {
     LOGGER.errorf("Not found: %s", e.getMessage());
     return Response.status(Status.NOT_FOUND)
         .entity(objectMapper.createObjectNode().put("error", "Not found"))
+        .build();
+  }
+
+  @ServerExceptionMapper
+  public Response mapForbiddenException(ForbiddenException e) {
+    LOGGER.errorf("Forbidden: %s", e.getMessage());
+    return Response.status(Status.FORBIDDEN)
+        .entity(objectMapper.createObjectNode().put("error", "Forbidden"))
+        .build();
+  }
+
+  @ServerExceptionMapper
+  public Response mapNotAuthorizedException(NotAuthorizedException e) {
+    LOGGER.errorf("Unauthorized: %s", e.getMessage());
+    return Response.status(Status.UNAUTHORIZED)
+        .entity(objectMapper.createObjectNode().put("error", "Unauthorized"))
         .build();
   }
 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportAuditService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportAuditService.java
@@ -35,20 +35,54 @@ public class ReportAuditService {
     @Inject
     ReportAuditRepositoryService repository;
 
+    /**
+     * Records an audit intent with {@code deleted=false}. Call {@link #deleteSucceeded(List)}
+     * only after the corresponding report removal succeeds.
+     */
     public void record(String actor, ReportAuditOperation operation, List<String> reportIds,
             Map<String, Object> context) {
+        Instant timestamp = Instant.now();
+        List<String> ids = List.copyOf(reportIds);
         ReportAuditLog log = new ReportAuditLog(
                 actor,
-                Instant.now(),
+                timestamp,
                 operation,
-                List.copyOf(reportIds),
-                context);
+                ids,
+                context,
+                false);
         try {
             repository.insert(log);
-            LOGGER.debugf("Recorded audit %s for actor=%s reportIds=%s", operation, actor, reportIds);
+            LOGGER.debugf("Recorded audit intent %s for actor=%s reportIds=%s deleted=false",
+                    operation, actor, ids);
         } catch (RuntimeException e) {
-            LOGGER.errorf(e, "Failed to record audit %s for actor=%s", operation, actor);
-            throw e;
+            LOGGER.errorf(e,
+                "Failed to record audit trail: actor=%s operation=%s timestamp=%s reportIds=%s context=%s",
+                actor, operation, timestamp, ids, context);
+            throw new RuntimeException("Operation temporarily unavailable");
         }
+    }
+
+    /**
+     * Confirms that report removal succeeded for the given IDs.
+     * Only allowed mutation of an audit document: set {@code deleted} to {@code true}.
+     */
+    public void deleteSucceeded(List<String> reportIds) {
+        List<String> ids = List.copyOf(reportIds);
+        try {
+            markDeletedTrue(ids);
+        } catch (RuntimeException e) {
+            LOGGER.errorf(e,
+                "Failed to confirm audit deletion after successful remove: reportIds=%s", ids);
+        }
+    }
+
+    private void markDeletedTrue(List<String> reportIds) {
+        boolean updated = repository.markDeletedTrue(reportIds);
+        if (!updated) {
+            LOGGER.errorf(
+                "No pending audit trail found to confirm deletion for reportIds=%s", reportIds);
+            return;
+        }
+        LOGGER.debugf("Confirmed audit deletion for reportIds=%s", reportIds);
     }
 }

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportAuditService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportAuditService.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.service;
+
+import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditLog;
+import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditOperation;
+import com.redhat.ecosystemappeng.exploitiq.repository.ReportAuditRepositoryService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+public class ReportAuditService {
+
+    public static final String PURGE_ACTOR = "system:purge";
+
+    private static final Logger LOGGER = Logger.getLogger(ReportAuditService.class);
+
+    @Inject
+    ReportAuditRepositoryService repository;
+
+    public void record(String actor, ReportAuditOperation operation, List<String> reportIds,
+            Map<String, Object> context) {
+        ReportAuditLog log = new ReportAuditLog(
+                actor,
+                Instant.now(),
+                operation,
+                List.copyOf(reportIds),
+                context);
+        try {
+            repository.insert(log);
+            LOGGER.debugf("Recorded audit %s for actor=%s reportIds=%s", operation, actor, reportIds);
+        } catch (RuntimeException e) {
+            LOGGER.errorf(e, "Failed to record audit %s for actor=%s", operation, actor);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
@@ -165,13 +165,15 @@ public class ReportService {
     if(purgeCron.isPresent()) {
       scheduler.newJob("purge_job").setCron(purgeCron.get()).setTask(executionContext -> {
         Instant threshold = Instant.now().minus(purgeAfter);
-        List<String> deletedIds = repository.removeBefore(threshold);
-        if (!deletedIds.isEmpty()) {
+        List<String> idsToDelete = repository.findIdsSubmittedBefore(threshold);
+        if (!idsToDelete.isEmpty()) {
           reportAuditService.record(
               ReportAuditService.PURGE_ACTOR,
               ReportAuditOperation.DELETE_PURGE,
-              deletedIds,
+              idsToDelete,
               Map.of("threshold", threshold.toString()));
+          repository.removeBefore(threshold);
+          reportAuditService.deleteSucceeded(idsToDelete);
         }
       }).schedule();
     }
@@ -301,7 +303,11 @@ public class ReportService {
     LOGGER.debugf("Remove report %s by actor %s", id, actor);
     reportAuditService.record(actor, ReportAuditOperation.DELETE_SINGLE, List.of(id), null);
     queueService.deleted(id);
-    return repository.remove(id);
+    boolean removed = repository.remove(id);
+    if (removed) {
+      reportAuditService.deleteSucceeded(List.of(id));
+    }
+    return removed;
   }
 
   public boolean remove(String actor, Collection<String> ids) {
@@ -309,7 +315,11 @@ public class ReportService {
     List<String> idList = ids instanceof List ? (List<String>) ids : List.copyOf(ids);
     reportAuditService.record(actor, ReportAuditOperation.DELETE_BULK, idList, null);
     queueService.deleted(ids);
-    return repository.remove(ids);
+    boolean removed = repository.remove(ids);
+    if (removed) {
+      reportAuditService.deleteSucceeded(idList);
+    }
+    return removed;
   }
 
   public boolean remove(String actor, ReportAuditOperation operation, Collection<String> ids,
@@ -318,7 +328,11 @@ public class ReportService {
     List<String> idList = ids instanceof List ? (List<String>) ids : List.copyOf(ids);
     reportAuditService.record(actor, operation, idList, context);
     queueService.deleted(ids);
-    return repository.remove(ids);
+    boolean removed = repository.remove(ids);
+    if (removed) {
+      reportAuditService.deleteSucceeded(idList);
+    }
+    return removed;
   }
 
   /**
@@ -349,14 +363,18 @@ public class ReportService {
   public Collection<String> remove(String actor, Map<String, String> query) {
     LOGGER.debugf("Remove reports with filter: %s by actor %s", query, actor);
     List<String> deleteIds = repository.findIdsByFilter(query);
+    if (deleteIds.isEmpty()) {
+      return deleteIds;
+    }
     reportAuditService.record(
         actor,
         ReportAuditOperation.DELETE_BULK_FILTER,
         deleteIds,
         Map.of("filter", Map.copyOf(query)));
-    if (!deleteIds.isEmpty()) {
-      queueService.deleted(deleteIds);
-      repository.remove(deleteIds);
+    queueService.deleted(deleteIds);
+    boolean removed = repository.remove(deleteIds);
+    if (removed) {
+      reportAuditService.deleteSucceeded(deleteIds);
     }
     return deleteIds;
   }

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
@@ -59,6 +59,7 @@ import com.redhat.ecosystemappeng.exploitiq.model.ReportRequest;
 import com.redhat.ecosystemappeng.exploitiq.model.ReportRequestId;
 import com.redhat.ecosystemappeng.exploitiq.model.ReportWithStatus;
 import com.redhat.ecosystemappeng.exploitiq.model.SortField;
+import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditOperation;
 import com.redhat.ecosystemappeng.exploitiq.repository.ProductRepositoryService;
 import com.redhat.ecosystemappeng.exploitiq.repository.ReportRepositoryService;
 import com.redhat.ecosystemappeng.exploitiq.exception.SbomValidationIssueCode;
@@ -73,10 +74,13 @@ import com.redhat.ecosystemappeng.exploitiq.rest.NotificationSocket;
 
 import io.quarkus.runtime.Startup;
 import io.quarkus.scheduler.Scheduler;
+import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
 
 import static com.redhat.ecosystemappeng.exploitiq.tracing.TextMapPropagatorImpl.getTraceIdFromContext;
 
@@ -137,6 +141,9 @@ public class ReportService {
   UserService userService;
 
   @Inject
+  ReportAuditService reportAuditService;
+
+  @Inject
   Scheduler scheduler;
 
   @ConfigProperty(name= "client.global.github.api-key", defaultValue = "")
@@ -157,7 +164,15 @@ public class ReportService {
     excludes = getMappingConfig(excludesPath);
     if(purgeCron.isPresent()) {
       scheduler.newJob("purge_job").setCron(purgeCron.get()).setTask(executionContext -> {
-        repository.removeBefore(Instant.now().minus(purgeAfter));
+        Instant threshold = Instant.now().minus(purgeAfter);
+        List<String> deletedIds = repository.removeBefore(threshold);
+        if (!deletedIds.isEmpty()) {
+          reportAuditService.record(
+              ReportAuditService.PURGE_ACTOR,
+              ReportAuditOperation.DELETE_PURGE,
+              deletedIds,
+              Map.of("threshold", threshold.toString()));
+        }
       }).schedule();
     }
   }
@@ -282,14 +297,26 @@ public class ReportService {
     }
   }
 
-  public boolean remove(String id) {
-    LOGGER.debugf("Remove report %s", id);
+  public boolean remove(String actor, String id) {
+    LOGGER.debugf("Remove report %s by actor %s", id, actor);
+    reportAuditService.record(actor, ReportAuditOperation.DELETE_SINGLE, List.of(id), null);
     queueService.deleted(id);
     return repository.remove(id);
   }
 
-  public boolean remove(Collection<String> ids) {
-    LOGGER.debugf("Remove reports %s", ids.toString());
+  public boolean remove(String actor, Collection<String> ids) {
+    LOGGER.debugf("Remove reports %s by actor %s", ids, actor);
+    List<String> idList = ids instanceof List ? (List<String>) ids : List.copyOf(ids);
+    reportAuditService.record(actor, ReportAuditOperation.DELETE_BULK, idList, null);
+    queueService.deleted(ids);
+    return repository.remove(ids);
+  }
+
+  public boolean remove(String actor, ReportAuditOperation operation, Collection<String> ids,
+      Map<String, Object> context) {
+    LOGGER.debugf("Remove reports %s by actor %s operation %s", ids, actor, operation);
+    List<String> idList = ids instanceof List ? (List<String>) ids : List.copyOf(ids);
+    reportAuditService.record(actor, operation, idList, context);
     queueService.deleted(ids);
     return repository.remove(ids);
   }
@@ -298,20 +325,53 @@ public class ReportService {
    * Marks all reports with the given scan ID as failed with the given error type and message.
    *
    * @throws jakarta.ws.rs.NotFoundException if no report exists for the given scan ID
+   * @throws ForbiddenException if a human caller does not own all matching reports
    */
-  public void markFailedByScanId(String scanId, String errorType, String errorMessage) {
-    LOGGER.debugf("Mark reports failed by scan ID %s: %s - %s", scanId, errorType, errorMessage);
-    int updated = repository.updateWithErrorByScanId(scanId, errorType, errorMessage);
-    if (updated == 0) {
+  public void markFailedByScanId(String scanId, String errorType, String errorMessage, String actor,
+      SecurityContext securityContext) {
+    LOGGER.debugf("Mark reports failed by scan ID %s: %s - %s (actor=%s)", scanId, errorType, errorMessage, actor);
+    List<Report> reports = repository.findByName(scanId);
+    if (reports.isEmpty()) {
       throw new jakarta.ws.rs.NotFoundException("No reports found for scan ID: " + scanId);
     }
+    if (requiresOwnerVerification(securityContext)) {
+      verifyReportOwnership(actor, reports);
+    }
+    List<String> reportIds = reports.stream().map(Report::id).toList();
+    reportAuditService.record(
+        actor,
+        ReportAuditOperation.MODIFY_STATUS,
+        reportIds,
+        Map.of("scanId", scanId, "errorType", errorType, "errorMessage", errorMessage));
+    repository.updateWithErrorByScanId(scanId, errorType, errorMessage);
   }
 
-  public Collection<String> remove(Map<String, String> query) {
-    LOGGER.debugf("Remove reports with filter: %s", query);
-    Collection<String> deleteIds = repository.remove(query);
-    queueService.deleted(deleteIds);
+  public Collection<String> remove(String actor, Map<String, String> query) {
+    LOGGER.debugf("Remove reports with filter: %s by actor %s", query, actor);
+    List<String> deleteIds = repository.findIdsByFilter(query);
+    reportAuditService.record(
+        actor,
+        ReportAuditOperation.DELETE_BULK_FILTER,
+        deleteIds,
+        Map.of("filter", Map.copyOf(query)));
+    if (!deleteIds.isEmpty()) {
+      queueService.deleted(deleteIds);
+      repository.remove(deleteIds);
+    }
     return deleteIds;
+  }
+
+  private boolean requiresOwnerVerification(SecurityContext securityContext) {
+    return !(securityContext.getUserPrincipal() instanceof JsonWebToken);
+  }
+
+  private void verifyReportOwnership(String actor, List<Report> reports) {
+    for (Report report : reports) {
+      String owner = Objects.nonNull(report.metadata()) ? report.metadata().get("user") : null;
+      if (Objects.isNull(owner) || !owner.equals(actor)) {
+        throw new ForbiddenException("Not authorized to modify reports for scan ID");
+      }
+    }
   }
 
   public boolean retry(String id) throws JsonProcessingException {

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportAuditRepositoryServiceTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportAuditRepositoryServiceTest.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.repository;
+
+import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditLog;
+import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditOperation;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@QuarkusTest
+class ReportAuditRepositoryServiceTest {
+
+    @Inject
+    ReportAuditRepositoryService repository;
+
+    @Test
+    void insertPersistsExpectedDocumentShape() {
+        long before = repository.countDocuments();
+        Instant timestamp = Instant.parse("2026-07-15T10:00:00Z");
+
+        repository.insert(new ReportAuditLog(
+                "test-actor",
+                timestamp,
+                ReportAuditOperation.DELETE_SINGLE,
+                List.of("507f1f77bcf86cd799439099"),
+                Map.of("note", "unit-test")));
+
+        Assertions.assertEquals(before + 1, repository.countDocuments());
+
+        Document latest = repository.findLatestByOperation(ReportAuditOperation.DELETE_SINGLE);
+        Assertions.assertNotNull(latest);
+        Assertions.assertEquals("test-actor", latest.getString("actor"));
+        Assertions.assertEquals("DELETE_SINGLE", latest.getString("operation"));
+        Assertions.assertEquals(List.of("507f1f77bcf86cd799439099"), latest.getList("report_ids", String.class));
+        Assertions.assertEquals("unit-test", latest.get("context", Document.class).getString("note"));
+    }
+}

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportAuditRepositoryServiceTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/repository/ReportAuditRepositoryServiceTest.java
@@ -24,16 +24,18 @@ class ReportAuditRepositoryServiceTest {
     ReportAuditRepositoryService repository;
 
     @Test
-    void insertPersistsExpectedDocumentShape() {
+    void insertPersistsExpectedDocumentShapeWithDeletedFalse() {
         long before = repository.countDocuments();
         Instant timestamp = Instant.parse("2026-07-15T10:00:00Z");
+        List<String> reportIds = List.of("507f1f77bcf86cd799439099");
 
         repository.insert(new ReportAuditLog(
                 "test-actor",
                 timestamp,
                 ReportAuditOperation.DELETE_SINGLE,
-                List.of("507f1f77bcf86cd799439099"),
-                Map.of("note", "unit-test")));
+                reportIds,
+                Map.of("note", "unit-test"),
+                false));
 
         Assertions.assertEquals(before + 1, repository.countDocuments());
 
@@ -41,7 +43,26 @@ class ReportAuditRepositoryServiceTest {
         Assertions.assertNotNull(latest);
         Assertions.assertEquals("test-actor", latest.getString("actor"));
         Assertions.assertEquals("DELETE_SINGLE", latest.getString("operation"));
-        Assertions.assertEquals(List.of("507f1f77bcf86cd799439099"), latest.getList("report_ids", String.class));
+        Assertions.assertEquals(reportIds, latest.getList("report_ids", String.class));
         Assertions.assertEquals("unit-test", latest.get("context", Document.class).getString("note"));
+        Assertions.assertEquals(Boolean.FALSE, latest.getBoolean("deleted"));
+    }
+
+    @Test
+    void markDeletedTrueConfirmsPendingAudit() {
+        List<String> reportIds = List.of("507f1f77bcf86cd7994390aa");
+        repository.insert(new ReportAuditLog(
+                "test-actor",
+                Instant.now(),
+                ReportAuditOperation.DELETE_BULK,
+                reportIds,
+                null,
+                false));
+
+        Assertions.assertTrue(repository.markDeletedTrue(reportIds));
+
+        Document latest = repository.findLatestByOperation(ReportAuditOperation.DELETE_BULK);
+        Assertions.assertNotNull(latest);
+        Assertions.assertEquals(Boolean.TRUE, latest.getBoolean("deleted"));
     }
 }

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpointAuditRestTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpointAuditRestTest.java
@@ -50,6 +50,7 @@ class ReportEndpointAuditRestTest {
         Assertions.assertNotNull(audit);
         Assertions.assertEquals("anonymous", audit.getString("actor"));
         Assertions.assertEquals(REPORT_ID, audit.getList("report_ids", String.class).getFirst());
+        Assertions.assertEquals(Boolean.TRUE, audit.getBoolean("deleted"));
     }
 
     @Test
@@ -71,5 +72,6 @@ class ReportEndpointAuditRestTest {
         Assertions.assertEquals(
             "failed-single-repo-scan-1",
             audit.get("context", Document.class).get("filter", Document.class).getString("reportId"));
+        Assertions.assertEquals(Boolean.TRUE, audit.getBoolean("deleted"));
     }
 }

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpointAuditRestTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpointAuditRestTest.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.rest;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Map;
+
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditOperation;
+import com.redhat.ecosystemappeng.exploitiq.repository.ReportAuditRepositoryService;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+class ReportEndpointAuditRestTest {
+
+    private static final String REPORT_ID = "507f1f77bcf86cd79943909a";
+
+    @Inject
+    ReportAuditRepositoryService auditRepository;
+
+    @BeforeEach
+    void configureRestAssured() {
+        RestApiTestFixture.configureRestAssuredIfExternal();
+    }
+
+    @Test
+    void deleteSingleReportWritesAuditRecord() {
+        long before = auditRepository.countDocuments();
+
+        RestAssured.given()
+            .when()
+            .delete("/api/v1/reports/{id}", REPORT_ID)
+            .then()
+            .statusCode(202);
+
+        Assertions.assertEquals(before + 1, auditRepository.countDocuments());
+
+        Document audit = auditRepository.findLatestByOperation(ReportAuditOperation.DELETE_SINGLE);
+        Assertions.assertNotNull(audit);
+        Assertions.assertEquals("anonymous", audit.getString("actor"));
+        Assertions.assertEquals(REPORT_ID, audit.getList("report_ids", String.class).getFirst());
+    }
+
+    @Test
+    void deleteByFilterWritesAuditRecordWithFilterContext() {
+        long before = auditRepository.countDocuments();
+
+        RestAssured.given()
+            .queryParam("reportId", "failed-single-repo-scan-1")
+            .when()
+            .delete("/api/v1/reports")
+            .then()
+            .statusCode(202);
+
+        Assertions.assertEquals(before + 1, auditRepository.countDocuments());
+
+        Document audit = auditRepository.findLatestByOperation(ReportAuditOperation.DELETE_BULK_FILTER);
+        Assertions.assertNotNull(audit);
+        Assertions.assertEquals("anonymous", audit.getString("actor"));
+        Assertions.assertEquals(
+            "failed-single-repo-scan-1",
+            audit.get("context", Document.class).get("filter", Document.class).getString("reportId"));
+    }
+}

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpointFailedRestTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpointFailedRestTest.java
@@ -22,14 +22,15 @@ public class ReportEndpointFailedRestTest {
         RestApiTestFixture.configureRestAssuredIfExternal();
     }
 
-    private static final String EXISTING_SCAN_ID = "test-scan-no-output-info";
+    /** Devservices {@code rpm.json}; stable anonymous owner across full test suite. */
+    private static final String ANONYMOUS_OWNED_SCAN_ID = "ea2c8e14-ba86-4cc1-9dee-5deca984be81";
     private static final String FOREIGN_OWNED_SCAN_ID = "test-single-repo-1";
     private static final String NON_EXISTENT_SCAN_ID = "non-existent-scan-id-12345";
 
     @Test
     void testPostFailed_returns202AndScanIdInBody() {
         Map<String, String> body = Map.of(
-            "scanId", EXISTING_SCAN_ID,
+            "scanId", ANONYMOUS_OWNED_SCAN_ID,
             "errorType", "processing-error",
             "errorMessage", "Test failure from ReportEndpointFailedTest"
         );
@@ -41,7 +42,7 @@ public class ReportEndpointFailedRestTest {
             .post("/api/v1/reports/failed")
             .then()
             .statusCode(202)
-            .body(equalTo(EXISTING_SCAN_ID));
+            .body(equalTo(ANONYMOUS_OWNED_SCAN_ID));
     }
 
     @Test

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpointFailedRestTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpointFailedRestTest.java
@@ -23,6 +23,7 @@ public class ReportEndpointFailedRestTest {
     }
 
     private static final String EXISTING_SCAN_ID = "test-scan-no-output-info";
+    private static final String FOREIGN_OWNED_SCAN_ID = "test-single-repo-1";
     private static final String NON_EXISTENT_SCAN_ID = "non-existent-scan-id-12345";
 
     @Test
@@ -41,6 +42,23 @@ public class ReportEndpointFailedRestTest {
             .then()
             .statusCode(202)
             .body(equalTo(EXISTING_SCAN_ID));
+    }
+
+    @Test
+    void testPostFailed_returns403WhenCallerDoesNotOwnReport() {
+        Map<String, String> body = Map.of(
+            "scanId", FOREIGN_OWNED_SCAN_ID,
+            "errorType", "processing-error",
+            "errorMessage", "Should be denied"
+        );
+
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .body(body)
+            .when()
+            .post("/api/v1/reports/failed")
+            .then()
+            .statusCode(403);
     }
 
     @Test

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceAuditTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceAuditTest.java
@@ -41,6 +41,7 @@ class ReportServiceAuditTest {
         Document audit = auditRepository.findLatestByOperation(ReportAuditOperation.DELETE_SINGLE);
         Assertions.assertNotNull(audit);
         Assertions.assertEquals("anonymous", audit.getString("actor"));
+        Assertions.assertEquals(Boolean.TRUE, audit.getBoolean("deleted"));
     }
 
     @Test

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceAuditTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceAuditTest.java
@@ -20,8 +20,9 @@ import org.mockito.Mockito;
 @QuarkusTest
 class ReportServiceAuditTest {
 
-    private static final String OWNED_SCAN_ID = "test-scan-no-output-info";
-    private static final String FOREIGN_SCAN_ID = "test-single-repo-1";
+    /** Devservices {@code rpm.json}; not mutated by other REST tests (unlike test-scan-no-output-info). */
+    private static final String ANONYMOUS_OWNED_SCAN_ID = "ea2c8e14-ba86-4cc1-9dee-5deca984be81";
+    private static final String FOREIGN_OWNED_SCAN_ID = "test-single-repo-1";
     private static final String REPORT_ID = "507f1f77bcf86cd79943909e";
 
     @Inject
@@ -48,12 +49,13 @@ class ReportServiceAuditTest {
         SecurityContext securityContext = devSecurityContext();
 
         reportService.markFailedByScanId(
-            OWNED_SCAN_ID, "processing-error", "owner allowed", "anonymous", securityContext);
+            ANONYMOUS_OWNED_SCAN_ID, "processing-error", "owner allowed", "anonymous", securityContext);
 
         Assertions.assertEquals(before + 1, auditRepository.countDocuments());
         Document audit = auditRepository.findLatestByOperation(ReportAuditOperation.MODIFY_STATUS);
         Assertions.assertNotNull(audit);
-        Assertions.assertEquals(OWNED_SCAN_ID, audit.get("context", Document.class).getString("scanId"));
+        Assertions.assertEquals(
+            ANONYMOUS_OWNED_SCAN_ID, audit.get("context", Document.class).getString("scanId"));
     }
 
     @Test
@@ -64,7 +66,7 @@ class ReportServiceAuditTest {
         Assertions.assertThrows(
             ForbiddenException.class,
             () -> reportService.markFailedByScanId(
-                FOREIGN_SCAN_ID, "processing-error", "denied", "anonymous", securityContext));
+                FOREIGN_OWNED_SCAN_ID, "processing-error", "denied", "anonymous", securityContext));
 
         Assertions.assertEquals(before, auditRepository.countDocuments());
     }

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceAuditTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceAuditTest.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.service;
+
+import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditOperation;
+import com.redhat.ecosystemappeng.exploitiq.repository.ReportAuditRepositoryService;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.security.ForbiddenException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.SecurityContext;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@QuarkusTest
+class ReportServiceAuditTest {
+
+    private static final String OWNED_SCAN_ID = "test-scan-no-output-info";
+    private static final String FOREIGN_SCAN_ID = "test-single-repo-1";
+    private static final String REPORT_ID = "507f1f77bcf86cd79943909e";
+
+    @Inject
+    ReportService reportService;
+
+    @Inject
+    ReportAuditRepositoryService auditRepository;
+
+    @Test
+    void removeSingleWritesAuditRecord() {
+        long before = auditRepository.countDocuments();
+
+        reportService.remove("anonymous", REPORT_ID);
+
+        Assertions.assertEquals(before + 1, auditRepository.countDocuments());
+        Document audit = auditRepository.findLatestByOperation(ReportAuditOperation.DELETE_SINGLE);
+        Assertions.assertNotNull(audit);
+        Assertions.assertEquals("anonymous", audit.getString("actor"));
+    }
+
+    @Test
+    void markFailedByScanIdAllowsOwnerInDevMode() {
+        long before = auditRepository.countDocuments();
+        SecurityContext securityContext = devSecurityContext();
+
+        reportService.markFailedByScanId(
+            OWNED_SCAN_ID, "processing-error", "owner allowed", "anonymous", securityContext);
+
+        Assertions.assertEquals(before + 1, auditRepository.countDocuments());
+        Document audit = auditRepository.findLatestByOperation(ReportAuditOperation.MODIFY_STATUS);
+        Assertions.assertNotNull(audit);
+        Assertions.assertEquals(OWNED_SCAN_ID, audit.get("context", Document.class).getString("scanId"));
+    }
+
+    @Test
+    void markFailedByScanIdRejectsForeignOwner() {
+        long before = auditRepository.countDocuments();
+        SecurityContext securityContext = devSecurityContext();
+
+        Assertions.assertThrows(
+            ForbiddenException.class,
+            () -> reportService.markFailedByScanId(
+                FOREIGN_SCAN_ID, "processing-error", "denied", "anonymous", securityContext));
+
+        Assertions.assertEquals(before, auditRepository.countDocuments());
+    }
+
+    private static SecurityContext devSecurityContext() {
+        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+        Mockito.when(securityContext.getUserPrincipal()).thenReturn(new QuarkusPrincipal("anonymous"));
+        return securityContext;
+    }
+}

--- a/src/test/resources/devservices/reports/test-scan-no-output-info.json
+++ b/src/test/resources/devservices/reports/test-scan-no-output-info.json
@@ -40,6 +40,6 @@
   "metadata": {
     "submitted_at": "2025-01-15T09:00:00.000000Z",
     "sent_at": "2025-01-15T09:00:00.000000Z",
-    "user": "test@example.com"
+    "user": "anonymous"
   }
 }


### PR DESCRIPTION
## Summary
Adds append-only audit logging for destructive report operations to address a security finding: deletions and status overrides previously ran **without recording** who performed them or which reports were affected.
[Jira](https://redhat.atlassian.net/issues?filter=106533&selectedIssue=APPENG-5706)

- Introduces a dedicated MongoDB collection `report_audit_trail` with insert-only persistence (`ReportAuditLog`, `ReportAuditOperation`, `ReportAuditRepositoryService`, `ReportAuditService)`,( following the same pattern as the feedbacks collection)
- Wires all destructive `ReportEndpoint `handlers to resolve the authenticated actor via SecurityContext + `UtilitiesService.getAuthenticatedUserName`; unauthenticated callers receive 401.
- Writes an audit record before each mutation, capturing actor, timestamp, operation, report_ids, and optional context (filters, product IDs, scan ID, purge threshold).
- Covers operations: DELETE_SINGLE, DELETE_BULK, DELETE_BULK_FILTER, DELETE_BY_PRODUCT, DELETE_BY_PRODUCTS, MODIFY_STATUS, and scheduled DELETE_PURGE (system:purge).
- Adds owner verification on `POST /api/v1/reports/failed`: human users may only mark reports they own (`metadata.user`); JWT service accounts bypass for ExploitIQ callbacks. Unauthorized attempts return 403 with no audit row.
- Extends `ReportRepositoryService` with `findIdsByFilter `and removeBefore returning deleted IDs for purge auditing.

Non-goals: No audit read/query API, no retroactive backfill, no changes to bulk-delete filter semantics beyond logging.

- [x] Collection `report_audit_trail` chosen for explicit compliance semantics; can shorten to `report_audits` if team prefers shorter names...
