### PR TITLE
fix: expired session redirect to login  instead of false analysis errors

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -78,6 +78,9 @@ quarkus.oidc.cache-user-info-in-idtoken=true
 quarkus.oidc.token.verify-access-token-with-user-info=false
 quarkus.oidc.authentication.id-token-required=false
 quarkus.oidc.client-id=exploit-iq-client
+# SPA fetch cannot follow OIDC 302 redirects (CORS on IdP). Return 499 instead so
+# the UI can reload and let the browser complete the login challenge.
+quarkus.oidc.authentication.java-script-auto-redirect=false
 
 # --- PROFILE: dev (Keycloak DevServices) ---
 # Read roles from JWT access token (Keycloak stores roles there)

--- a/src/main/webui/package.json
+++ b/src/main/webui/package.json
@@ -8,6 +8,8 @@
     "dev:msw": "VITE_ENABLE_MSW=true vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "openapi:postprocess": "jq 'del(.servers)' ../../../target/generated/openapi/openapi.json > openapi.json.tmp && mv openapi.json.tmp openapi.json || (echo 'Warning: OpenAPI spec not found. Run openapi:generate first.' && exit 1)",
     "openapi:generate": "cd ../../.. && ./mvnw clean package -DskipTests -Dquarkus.quinoa.enabled=false && cd src/main/webui && npm run openapi:postprocess",
@@ -43,7 +45,8 @@
     "openapi-typescript": "^7.0.0",
     "openapi-typescript-codegen": "^0.29.0",
     "typescript": "^5.5.4",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^3.2.7"
   },
   "msw": {
     "workerDirectory": [

--- a/src/main/webui/src/config/apiClient.ts
+++ b/src/main/webui/src/config/apiClient.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Configures the generated OpenAPI client for browser cookie/OIDC sessions.
+ *
+ * Quarkus treats requests with {@code X-Requested-With: XMLHttpRequest} as
+ * JavaScript requests. With
+ * {@code quarkus.oidc.authentication.java-script-auto-redirect=false}, expired
+ * sessions return HTTP 499 instead of a 302 to the IdP (which fetch cannot
+ * follow due to CORS — surfacing as TypeError "Failed to fetch").
+ */
+
+import { OpenAPI } from "../generated-client";
+
+/** Header Quarkus OIDC uses to detect SPA/XHR requests (default checker). */
+export const JS_REQUEST_HEADER = {
+  "X-Requested-With": "XMLHttpRequest",
+} as const;
+
+export function configureApiClient(): void {
+  OpenAPI.WITH_CREDENTIALS = true;
+  OpenAPI.CREDENTIALS = "include";
+  OpenAPI.HEADERS = {
+    ...JS_REQUEST_HEADER,
+  };
+}

--- a/src/main/webui/src/hooks/useApi.ts
+++ b/src/main/webui/src/hooks/useApi.ts
@@ -19,6 +19,7 @@
 import { useState, useEffect, useRef } from "react";
 import type { CancelablePromise } from "../generated-client";
 import { useLiveUpdatesRevision } from "../contexts/LiveUpdatesContext";
+import { redirectToLoginIfUnauthorized } from "../utils/errorHandling";
 
 export interface UseApiResult<T> {
   data: T | null;
@@ -102,6 +103,10 @@ export function useApi<T>(
             return;
           }
 
+          if (redirectToLoginIfUnauthorized(err)) {
+            return;
+          }
+
           if (!cancelledRef.current) {
             setError(err instanceof Error ? err : new Error(String(err)));
             setLoading(false);
@@ -110,6 +115,9 @@ export function useApi<T>(
           }
         });
     } catch (err) {
+      if (redirectToLoginIfUnauthorized(err)) {
+        return;
+      }
       if (!cancelledRef.current) {
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);

--- a/src/main/webui/src/hooks/useAuth.ts
+++ b/src/main/webui/src/hooks/useAuth.ts
@@ -16,6 +16,7 @@
  */
 
 import { useApi } from './useApi';
+import { JS_REQUEST_HEADER } from '../config/apiClient';
 import { redirectToLogin } from '../utils/errorHandling';
 
 export interface UserInfo {
@@ -42,13 +43,14 @@ export function useAuth() {
     async () => {
       const response = await fetch('/api/v1/user', {
         headers: {
-          'Accept': 'application/json',
+          Accept: 'application/json',
+          ...JS_REQUEST_HEADER,
         },
         credentials: 'include', // Include cookies for authentication
       });
 
       if (!response.ok) {
-        if (response.status === 401) {
+        if (response.status === 401 || response.status === 499) {
           redirectToLogin();
           throw new Error('Unauthorized - redirecting to login');
         }

--- a/src/main/webui/src/hooks/useAuth.ts
+++ b/src/main/webui/src/hooks/useAuth.ts
@@ -16,6 +16,7 @@
  */
 
 import { useApi } from './useApi';
+import { redirectToLogin } from '../utils/errorHandling';
 
 export interface UserInfo {
   name: string;
@@ -47,8 +48,8 @@ export function useAuth() {
       });
 
       if (!response.ok) {
-        // If unauthorized, the user needs to login (redirect handled by Quarkus)
         if (response.status === 401) {
+          redirectToLogin();
           throw new Error('Unauthorized - redirecting to login');
         }
         throw new Error(`Failed to fetch user info: ${response.status} ${response.statusText}`);

--- a/src/main/webui/src/hooks/useAuth.ts
+++ b/src/main/webui/src/hooks/useAuth.ts
@@ -51,8 +51,10 @@ export function useAuth() {
 
       if (!response.ok) {
         if (response.status === 401 || response.status === 499) {
+          // Reload starts the OIDC challenge; do not throw — useApi would treat it as a
+          // failed request and the message would not match auth-challenge detection.
           redirectToLogin();
-          throw new Error('Unauthorized - redirecting to login');
+          return new Promise<UserInfo>(() => {});
         }
         throw new Error(`Failed to fetch user info: ${response.status} ${response.statusText}`);
       }

--- a/src/main/webui/src/hooks/useExecuteApi.ts
+++ b/src/main/webui/src/hooks/useExecuteApi.ts
@@ -19,6 +19,7 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react';
 import type { CancelablePromise } from '../generated-client';
+import { redirectToLoginIfUnauthorized } from '../utils/errorHandling';
 
 export interface UseExecuteApiResult<T> {
   data: T | null;
@@ -83,6 +84,10 @@ export function useExecuteApi<T>(
           if (err?.isCancelled || err?.name === 'CancelError') {
             return;
           }
+
+          if (redirectToLoginIfUnauthorized(err)) {
+            return;
+          }
           
           if (!cancelledRef.current) {
             setError(err instanceof Error ? err : new Error(String(err)));
@@ -91,6 +96,9 @@ export function useExecuteApi<T>(
           }
         });
     } catch (err) {
+      if (redirectToLoginIfUnauthorized(err)) {
+        return;
+      }
       if (!cancelledRef.current) {
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);

--- a/src/main/webui/src/hooks/usePaginatedApi.ts
+++ b/src/main/webui/src/hooks/usePaginatedApi.ts
@@ -21,6 +21,7 @@ import { useLiveUpdatesRevision } from '../contexts/LiveUpdatesContext';
 import { OpenAPI } from '../generated-client/core/OpenAPI';
 import { getHeaders } from '../generated-client/core/request';
 import type { ApiRequestOptions } from '../generated-client/core/ApiRequestOptions';
+import { redirectToLogin, redirectToLoginIfUnauthorized } from '../utils/errorHandling';
 
 // Helper to build URL from request options (re-implemented since getUrl is not exported)
 const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
@@ -185,6 +186,10 @@ export function usePaginatedApi<T>(
       }
 
       if (!response.ok) {
+        if (response.status === 401) {
+          redirectToLogin();
+          throw new Error('HTTP 401: Unauthorized');
+        }
         const errorText = await response.text().catch(() => 'Unknown error');
         throw new Error(`HTTP ${response.status}: ${errorText}`);
       }
@@ -216,6 +221,10 @@ export function usePaginatedApi<T>(
     } catch (err) {
       // Ignore abort errors
       if (err instanceof Error && err.name === 'AbortError') {
+        return;
+      }
+
+      if (redirectToLoginIfUnauthorized(err)) {
         return;
       }
       

--- a/src/main/webui/src/hooks/usePaginatedApi.ts
+++ b/src/main/webui/src/hooks/usePaginatedApi.ts
@@ -187,8 +187,10 @@ export function usePaginatedApi<T>(
 
       if (!response.ok) {
         if (response.status === 401 || response.status === 499) {
+          // Reload starts the OIDC challenge; return without throwing so the catch
+          // block does not call redirectToLoginIfUnauthorized again.
           redirectToLogin();
-          throw new Error(`HTTP ${response.status}: Unauthorized`);
+          return;
         }
         const errorText = await response.text().catch(() => 'Unknown error');
         throw new Error(`HTTP ${response.status}: ${errorText}`);

--- a/src/main/webui/src/hooks/usePaginatedApi.ts
+++ b/src/main/webui/src/hooks/usePaginatedApi.ts
@@ -186,9 +186,9 @@ export function usePaginatedApi<T>(
       }
 
       if (!response.ok) {
-        if (response.status === 401) {
+        if (response.status === 401 || response.status === 499) {
           redirectToLogin();
-          throw new Error('HTTP 401: Unauthorized');
+          throw new Error(`HTTP ${response.status}: Unauthorized`);
         }
         const errorText = await response.text().catch(() => 'Unknown error');
         throw new Error(`HTTP ${response.status}: ${errorText}`);

--- a/src/main/webui/src/main.tsx
+++ b/src/main/webui/src/main.tsx
@@ -13,7 +13,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { configureApiClient } from "./config/apiClient";
 import "@patternfly/react-core/dist/styles/base.css";
+
+configureApiClient();
 
 /**
  * Conditionally enable MSW mocking based on environment variable

--- a/src/main/webui/src/utils/errorHandling.test.ts
+++ b/src/main/webui/src/utils/errorHandling.test.ts
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../generated-client";
+import type { ApiRequestOptions } from "../generated-client/core/ApiRequestOptions";
+import {
+  isUnauthorizedError,
+  redirectToLogin,
+  redirectToLoginIfUnauthorized,
+  resetUnauthorizedRedirectState,
+} from "./errorHandling";
+
+function apiError(status: number): ApiError {
+  const request = { method: "GET", url: "/api/v1/example" } as ApiRequestOptions;
+  return new ApiError(
+    request,
+    {
+      url: "/api/v1/example",
+      ok: false,
+      status,
+      statusText: status === 401 ? "Unauthorized" : "Client Closed Request",
+      body: undefined,
+    },
+    status === 401 ? "Unauthorized" : "Client Closed Request"
+  );
+}
+
+function stubBrowserGlobals(reloadMock: ReturnType<typeof vi.fn>) {
+  vi.stubGlobal("window", { location: { reload: reloadMock } });
+  vi.stubGlobal("sessionStorage", { clear: vi.fn() });
+}
+
+describe("isUnauthorizedError", () => {
+  it("returns true for ApiError with status 401", () => {
+    expect(isUnauthorizedError(apiError(401))).toBe(true);
+  });
+
+  it("returns true for ApiError with status 499", () => {
+    expect(isUnauthorizedError(apiError(499))).toBe(true);
+  });
+
+  it("returns false for ApiError with other statuses", () => {
+    expect(isUnauthorizedError(apiError(403))).toBe(false);
+    expect(isUnauthorizedError(apiError(500))).toBe(false);
+  });
+
+  it("returns true for HTTP 401/499 message errors", () => {
+    expect(isUnauthorizedError(new Error("HTTP 401: Unauthorized"))).toBe(true);
+    expect(isUnauthorizedError(new Error("HTTP 499: Client Closed Request"))).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isUnauthorizedError(new Error("Failed to fetch"))).toBe(false);
+    expect(isUnauthorizedError(new Error("HTTP 400: Bad Request"))).toBe(false);
+    expect(isUnauthorizedError("not an error")).toBe(false);
+    expect(isUnauthorizedError(null)).toBe(false);
+  });
+});
+
+describe("redirectToLogin", () => {
+  let reloadMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    resetUnauthorizedRedirectState();
+    reloadMock = vi.fn();
+    stubBrowserGlobals(reloadMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetUnauthorizedRedirectState();
+  });
+
+  it("clears sessionStorage and reloads the page", () => {
+    redirectToLogin();
+    expect(sessionStorage.clear).toHaveBeenCalledTimes(1);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("only clears storage and reloads once when called repeatedly", () => {
+    redirectToLogin();
+    redirectToLogin();
+    expect(sessionStorage.clear).toHaveBeenCalledTimes(1);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("redirectToLoginIfUnauthorized", () => {
+  let reloadMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    resetUnauthorizedRedirectState();
+    reloadMock = vi.fn();
+    stubBrowserGlobals(reloadMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetUnauthorizedRedirectState();
+  });
+
+  it("redirects and returns true for unauthorized ApiError", () => {
+    expect(redirectToLoginIfUnauthorized(apiError(401))).toBe(true);
+    expect(sessionStorage.clear).toHaveBeenCalledTimes(1);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("redirects and returns true for 499 ApiError", () => {
+    expect(redirectToLoginIfUnauthorized(apiError(499))).toBe(true);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false and does not reload for other errors", () => {
+    expect(redirectToLoginIfUnauthorized(new Error("Failed to fetch"))).toBe(false);
+    expect(redirectToLoginIfUnauthorized(apiError(403))).toBe(false);
+    expect(sessionStorage.clear).not.toHaveBeenCalled();
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/webui/src/utils/errorHandling.ts
+++ b/src/main/webui/src/utils/errorHandling.ts
@@ -52,9 +52,15 @@ export function redirectToLogin(): void {
     return;
   }
   unauthorizedRedirectInProgress = true;
+  sessionStorage.clear();
   // Same-document reload (not assign of a constructed URL) so Quarkus can start
   // the OIDC login challenge for the current path after the session is gone.
   window.location.reload();
+}
+
+/** Resets redirect guard state. Intended for unit tests only. */
+export function resetUnauthorizedRedirectState(): void {
+  unauthorizedRedirectInProgress = false;
 }
 
 /**
@@ -170,7 +176,11 @@ export function parseRequestAnalysisSubmissionError(
   fallbackMessage: string = DEFAULT_SUBMISSION_ERROR
 ): RequestAnalysisSubmissionError {
   if (redirectToLoginIfUnauthorized(error)) {
-    return { fieldErrors: {}, genericMessage: null };
+    // Brief message while the page reloads into the OIDC login challenge.
+    return {
+      fieldErrors: {},
+      genericMessage: "Session expired. Attempting re-authentication…",
+    };
   }
   if (isValidationError(error)) {
     const errors = error.body.errors ?? {};

--- a/src/main/webui/src/utils/errorHandling.ts
+++ b/src/main/webui/src/utils/errorHandling.ts
@@ -20,14 +20,23 @@ import type { ValidationErrorResponse } from "../generated-client/models/Validat
 let unauthorizedRedirectInProgress = false;
 
 /**
+ * Quarkus OIDC returns 499 for SPA/XHR when
+ * {@code java-script-auto-redirect=false} and re-authentication is required.
+ * 401 covers bearer/missing-auth cases.
+ */
+function isAuthChallengeStatus(status: number): boolean {
+  return status === 401 || status === 499;
+}
+
+/**
  * Returns true when the error indicates an expired or missing authentication session.
- * Covers generated-client {@link ApiError} (401) and fetch-style `HTTP 401: ...` errors.
+ * Covers generated-client {@link ApiError} (401/499) and fetch-style `HTTP 401|499: ...` errors.
  */
 export function isUnauthorizedError(error: unknown): boolean {
   if (error instanceof ApiError) {
-    return error.status === 401;
+    return isAuthChallengeStatus(error.status);
   }
-  if (error instanceof Error && /^HTTP 401\b/.test(error.message)) {
+  if (error instanceof Error && /^HTTP (401|499)\b/.test(error.message)) {
     return true;
   }
   return false;
@@ -49,7 +58,7 @@ export function redirectToLogin(): void {
 }
 
 /**
- * On 401 Unauthorized, redirects to login via {@link redirectToLogin}.
+ * On 401/499 auth challenge, redirects to login via {@link redirectToLogin}.
  *
  * @returns true if a redirect was started (caller should stop showing the error)
  */

--- a/src/main/webui/src/utils/errorHandling.ts
+++ b/src/main/webui/src/utils/errorHandling.ts
@@ -17,6 +17,49 @@
 import { ApiError } from "../generated-client";
 import type { ValidationErrorResponse } from "../generated-client/models/ValidationErrorResponse";
 
+let unauthorizedRedirectInProgress = false;
+
+/**
+ * Returns true when the error indicates an expired or missing authentication session.
+ * Covers generated-client {@link ApiError} (401) and fetch-style `HTTP 401: ...` errors.
+ */
+export function isUnauthorizedError(error: unknown): boolean {
+  if (error instanceof ApiError) {
+    return error.status === 401;
+  }
+  if (error instanceof Error && /^HTTP 401\b/.test(error.message)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Forces a full-page reload so Quarkus OIDC can challenge the user and show
+ * the login screen. React Router navigation is not enough — the SPA would stay
+ * mounted with a stale session.
+ */
+export function redirectToLogin(): void {
+  if (unauthorizedRedirectInProgress) {
+    return;
+  }
+  unauthorizedRedirectInProgress = true;
+  // Same-document reload (not assign of a constructed URL) so Quarkus can start
+  // the OIDC login challenge for the current path after the session is gone.
+  window.location.reload();
+}
+
+/**
+ * On 401 Unauthorized, redirects to login via {@link redirectToLogin}.
+ *
+ * @returns true if a redirect was started (caller should stop showing the error)
+ */
+export function redirectToLoginIfUnauthorized(error: unknown): boolean {
+  if (!isUnauthorizedError(error)) {
+    return false;
+  }
+  redirectToLogin();
+  return true;
+}
 
 /**
  * User-friendly error message formatter for API errors
@@ -117,6 +160,9 @@ export function parseRequestAnalysisSubmissionError(
   error: unknown,
   fallbackMessage: string = DEFAULT_SUBMISSION_ERROR
 ): RequestAnalysisSubmissionError {
+  if (redirectToLoginIfUnauthorized(error)) {
+    return { fieldErrors: {}, genericMessage: null };
+  }
   if (isValidationError(error)) {
     const errors = error.body.errors ?? {};
     const fieldErrors: Record<string, string> = {};

--- a/src/main/webui/vite.config.ts
+++ b/src/main/webui/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
@@ -9,6 +10,10 @@ const env = loadEnv('development', process.cwd(), '');
 const isStandalone = env.VITE_STANDALONE === 'true' || process.env.VITE_STANDALONE === 'true';
 const baseConfig = {
   plugins: [react()],
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
 };
 
 const getConfig = () => {


### PR DESCRIPTION
## Summary
When the UI token is expired, trying to run analysis shows a failure message which is incorrect.
  
### Expected Result
The Web UI should throw the user out of the application into the login screen

### Actual Result
It is possible to click on buttons and links without being thrown out and redirected to the login screen. In addition, when trying to run analysis, there is an error message in the UI saying that the analysis failed which is not true.

### Fix:

- Set `quarkus.oidc.authentication.java-script-auto-redirect=false` so Quarkus returns 499 for SPA/XHR auth challenges instead of a 302.
- Configure the OpenAPI client to send `X-Requested-With: XMLHttpRequest` and include credentials, so Quarkus recognizes browser API calls as JavaScript requests.
- On 401/499, redirect via a full page reload so Quarkus can start the login flow. Applied in shared API hooks and request-analysis submit error handling so expired auth no longer looks like a failed analysis.

[Jira](https://redhat.atlassian.net/issues?filter=-1&selectedIssue=TC-5224)
### Checks:
Delete:
<img width="415" height="230" alt="image" src="https://github.com/user-attachments/assets/eb2e9fa1-49d4-4024-a5fe-05bd042a4c29" />
Before (try to submit):
<img width="415" height="300" alt="image" src="https://github.com/user-attachments/assets/ee86a3f7-fb10-410d-9464-e80a575d567b" />
After :
<img width="415" height="300" alt="Screenshot From 2026-07-20 11-13-25" src="https://github.com/user-attachments/assets/fc1c10e8-f216-4d5e-aa05-c56aad5b072c" />

