### PR TITLE
fix: API access is no longer granted to every service account in the NS

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -117,7 +117,12 @@ quarkus.oidc.client-id=exploit-iq-client
 # RBAC (Role-Based Access Control)
 # ==============================================================================
 # Strategy:
-# - Global policy: Authenticated + Role (exploit-iq-view, exploit-iq-prodsec, exploit-iq-admin).
+# - Global policy: Authenticated + one of:
+#     User roles: exploit-iq-view, exploit-iq-prodsec, exploit-iq-admin
+#     OpenShift SAs (specific only — not all SAs in the namespace):
+#       system:serviceaccounts:${NAMESPACE}:exploit-iq-sa  (ExploitIQ agent)
+#       system:serviceaccounts:${NAMESPACE}:pipeline       (CI / MLOps pipelines)
+#     External IdP / Keycloak service accounts: exploitiq-api-access
 # - Exceptions: Specific paths (logout, health, dev-ui) are permitted.
 # ==============================================================================
 
@@ -136,7 +141,7 @@ quarkus.http.auth.permission.management.policy=permit
 %dev.quarkus.http.auth.permission.dev-ui.policy=permit
 
 # Global policy: Require authentication and at least one role
-quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,system:serviceaccounts:${NAMESPACE}
+quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,system:serviceaccounts:${NAMESPACE}:exploit-iq-sa,system:serviceaccounts:${NAMESPACE}:pipeline,exploitiq-api-access
 quarkus.http.auth.permission.default.paths=/*
 quarkus.http.auth.permission.default.policy=role-policy
 # No order specified = lowest priority (applied last, after exceptions)


### PR DESCRIPTION
## Summary
Updated the global RBAC policy so API access is no longer granted to every service account in the namespace.

**Before:** `system:serviceaccounts:${NAMESPACE}` (any SA in the namespace)

**After:** only these identities, plus the existing user roles:
- `system:serviceaccounts:${NAMESPACE}:exploit-iq-sa` — ExploitIQ agent
- `system:serviceaccounts:${NAMESPACE}:pipeline` — CI / MLOps pipelines
- `exploitiq-api-access` — external IdP / Keycloak service accounts

A compromised pod using any other SA in the namespace can no longer call `POST /api/v1/reports` (or other protected APIs) solely by being in the same namespace.

[Jira](https://redhat.atlassian.net/issues?filter=-1&selectedIssue=APPENG-5705)