### PR TITLE
fix: restore report owner verification on Keycloak by using SA roles

### DIFF
--- a/openspec/specs/report-audit-trail/spec.md
+++ b/openspec/specs/report-audit-trail/spec.md
@@ -70,7 +70,7 @@ All destructive `ReportEndpoint` handlers (`DELETE /reports/{id}`, `DELETE /repo
 
 ### Requirement: Owner verification for mark failed by scan ID
 
-`POST /api/v1/reports/failed` (`markFailedByScanId`) SHALL verify ownership before updating report status. For human users (callers without a configured service-account role), every report matching the scan ID SHALL have `metadata.user` equal to the actor. For service accounts (callers holding any role listed in `exploit-iq.security.service-account-roles`), owner verification SHALL be skipped. Service-account detection MUST be role-based and MUST NOT rely on JWT principal type, so it works across OpenShift OAuth and Keycloak. On success, the backend SHALL write an audit record with operation `MODIFY_STATUS`, affected `report_ids`, and `context` containing `scanId`, `errorType`, and `errorMessage`.
+`POST /api/v1/reports/failed` (`markFailedByScanId`) SHALL verify ownership before updating report status. For human users (callers without a configured service-account role), every report matching the scan ID SHALL have `metadata.user` equal to the actor. For service accounts (callers holding any role listed in `exploitiq.security.service-account-roles`), owner verification SHALL be skipped. Service-account detection MUST be role-based and MUST NOT rely on JWT principal type, so it works across OpenShift OAuth and Keycloak. On success, the backend SHALL write an audit record with operation `MODIFY_STATUS`, affected `report_ids`, and `context` containing `scanId`, `errorType`, and `errorMessage`.
 
 #### Scenario: Human user marks own report failed
 

--- a/openspec/specs/report-audit-trail/spec.md
+++ b/openspec/specs/report-audit-trail/spec.md
@@ -70,7 +70,7 @@ All destructive `ReportEndpoint` handlers (`DELETE /reports/{id}`, `DELETE /repo
 
 ### Requirement: Owner verification for mark failed by scan ID
 
-`POST /api/v1/reports/failed` (`markFailedByScanId`) SHALL verify ownership before updating report status. For human users (actor resolved via `UserService` without a JWT principal name), every report matching the scan ID SHALL have `metadata.user` equal to the actor. For service accounts (JWT principal name present per `UtilitiesService`), owner verification SHALL be skipped. On success, the backend SHALL write an audit record with operation `MODIFY_STATUS`, affected `report_ids`, and `context` containing `scanId`, `errorType`, and `errorMessage`.
+`POST /api/v1/reports/failed` (`markFailedByScanId`) SHALL verify ownership before updating report status. For human users (callers without a configured service-account role), every report matching the scan ID SHALL have `metadata.user` equal to the actor. For service accounts (callers holding any role listed in `exploit-iq.security.service-account-roles`), owner verification SHALL be skipped. Service-account detection MUST be role-based and MUST NOT rely on JWT principal type, so it works across OpenShift OAuth and Keycloak. On success, the backend SHALL write an audit record with operation `MODIFY_STATUS`, affected `report_ids`, and `context` containing `scanId`, `errorType`, and `errorMessage`.
 
 #### Scenario: Human user marks own report failed
 
@@ -88,7 +88,7 @@ All destructive `ReportEndpoint` handlers (`DELETE /reports/{id}`, `DELETE /repo
 
 #### Scenario: Service account may mark any matching report failed
 
-- **WHEN** an authenticated service account (JWT principal name present) calls `POST /api/v1/reports/failed` for an existing scan ID
+- **WHEN** an authenticated service account (holding a configured service-account role such as `exploitiq-api-access`) calls `POST /api/v1/reports/failed` for an existing scan ID
 - **THEN** the backend writes a `MODIFY_STATUS` audit record with the service principal as `actor`
 - **AND** updates all matching reports
 - **AND** returns **202 Accepted**

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/config/AppConfig.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/config/AppConfig.java
@@ -17,6 +17,7 @@ package com.redhat.ecosystemappeng.exploitiq.config;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
@@ -39,6 +40,16 @@ public interface AppConfig {
     Optional<Database> database();
     Optional<Audit> audit();
     Optional<SseConfig> sse();
+    Optional<Security> security();
+
+    interface Security {
+        /**
+         * Roles that identify service accounts (skip report owner verification).
+         * Keep aligned with SA entries in {@code quarkus.http.auth.policy.role-policy.roles-allowed}.
+         */
+        @WithName("service-account-roles")
+        Set<String> serviceAccountRoles();
+    }
 
     interface SseConfig {
         @WithName("heartbeat-interval")

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/config/AppConfig.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/config/AppConfig.java
@@ -17,7 +17,6 @@ package com.redhat.ecosystemappeng.exploitiq.config;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
@@ -40,16 +39,6 @@ public interface AppConfig {
     Optional<Database> database();
     Optional<Audit> audit();
     Optional<SseConfig> sse();
-    Optional<Security> security();
-
-    interface Security {
-        /**
-         * Roles that identify service accounts (skip report owner verification).
-         * Keep aligned with SA entries in {@code quarkus.http.auth.policy.role-policy.roles-allowed}.
-         */
-        @WithName("service-account-roles")
-        Set<String> serviceAccountRoles();
-    }
 
     interface SseConfig {
         @WithName("heartbeat-interval")

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentor.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentor.java
@@ -63,6 +63,9 @@ public class RoleMappingAugmentor implements SecurityIdentityAugmentor {
     @ConfigProperty(name = "quarkus.http.auth.policy.role-policy.roles-allowed", defaultValue = "exploit-iq-admin,exploit-iq-view,exploit-iq-prodsec")
     Set<String> targetRoles;
 
+    @ConfigProperty(name = "exploitiq.security.service-account-roles")
+    Set<String> serviceAccountRoles;
+
     @ConfigProperty(name = "quarkus.oidc.enabled", defaultValue = "true")
     boolean oidcEnabled;
 
@@ -71,21 +74,23 @@ public class RoleMappingAugmentor implements SecurityIdentityAugmentor {
     /**
      * Augments the security identity.
      *
-     * In DEV/TEST mode with OIDC disabled, it creates a mock privileged user.
+     * In DEV/TEST mode with OIDC disabled, it creates a mock privileged human user
+     * (application roles only — not service-account roles).
      * Otherwise, it maps OIDC token claims to application roles.
      */
     @Override
     public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
         if (!oidcEnabled && (LaunchMode.current() == LaunchMode.DEVELOPMENT || LaunchMode.current() == LaunchMode.TEST)
                 && identity.isAnonymous()) {
+            Set<String> humanRoles = humanTargetRoles();
             if (!loggedDevModeWarning) {
-                LOG.warnf("OIDC is disabled and in DEV/TEST mode. Granting anonymous user all target roles: %s",
-                        targetRoles);
+                LOG.warnf("OIDC is disabled and in DEV/TEST mode. Granting anonymous user human roles: %s",
+                        humanRoles);
                 loggedDevModeWarning = true;
             }
             return Uni.createFrom().item(QuarkusSecurityIdentity.builder()
                     .setPrincipal(new QuarkusPrincipal("anonymous"))
-                    .addRoles(targetRoles)
+                    .addRoles(humanRoles)
                     .build());
         }
 
@@ -194,5 +199,18 @@ public class RoleMappingAugmentor implements SecurityIdentityAugmentor {
                 addedRoles.add(roleName);
             }
         }
+    }
+
+    /**
+     * Human application roles only. Service-account roles are included in
+     * {@code roles-allowed} for HTTP auth, but must not be granted to the DEV/TEST
+     * anonymous mock user or owner verification is skipped.
+     */
+    private Set<String> humanTargetRoles() {
+        Set<String> humanRoles = new HashSet<>(targetRoles);
+        if (serviceAccountRoles != null) {
+            humanRoles.removeAll(serviceAccountRoles);
+        }
+        return humanRoles;
     }
 }

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
@@ -77,7 +77,6 @@ import io.quarkus.scheduler.Scheduler;
 import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
@@ -379,8 +378,15 @@ public class ReportService {
     return deleteIds;
   }
 
+  /**
+   * Owner verification applies to human users only. Service accounts are identified by role
+   * (not JWT principal type), so this works for OpenShift OAuth and Keycloak alike.
+   */
   private boolean requiresOwnerVerification(SecurityContext securityContext) {
-    return !(securityContext.getUserPrincipal() instanceof JsonWebToken);
+    Set<String> serviceAccountRoles = appConfig.security()
+        .map(AppConfig.Security::serviceAccountRoles)
+        .orElse(Set.of());
+    return serviceAccountRoles.stream().noneMatch(securityContext::isUserInRole);
   }
 
   private void verifyReportOwnership(String actor, List<Report> reports) {

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
@@ -157,6 +157,14 @@ public class ReportService {
   @ConfigProperty(name = "exploit-iq.purge.after", defaultValue = "7d")
   Duration purgeAfter;
 
+  /**
+   * Roles that identify service accounts (OIDC-provider agnostic). Callers with any of these
+   * roles skip report owner verification on mark-failed. Kept outside {@code exploit-iq.*}
+   * {@link AppConfig} mapping so values resolve at runtime (native-safe; {@code NAMESPACE} available).
+   */
+  @ConfigProperty(name = "exploitiq.security.service-account-roles")
+  Set<String> serviceAccountRoles;
+
   @Startup
   void loadConfig() throws FileNotFoundException, IOException {
     includes = getMappingConfig(includesPath);
@@ -383,9 +391,6 @@ public class ReportService {
    * (not JWT principal type), so this works for OpenShift OAuth and Keycloak alike.
    */
   private boolean requiresOwnerVerification(SecurityContext securityContext) {
-    Set<String> serviceAccountRoles = appConfig.security()
-        .map(AppConfig.Security::serviceAccountRoles)
-        .orElse(Set.of());
     return serviceAccountRoles.stream().noneMatch(securityContext::isUserInRole);
   }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -149,6 +149,10 @@ quarkus.http.auth.permission.default.paths=/*
 quarkus.http.auth.permission.default.policy=role-policy
 # No order specified = lowest priority (applied last, after exceptions)
 
+# Service-account roles used to skip report owner verification (OIDC-provider agnostic).
+# Keep in sync with the SA entries in role-policy.roles-allowed above.
+exploit-iq.security.service-account-roles=system:serviceaccounts:${NAMESPACE}:exploit-iq-sa,system:serviceaccounts:${NAMESPACE}:pipeline,exploitiq-api-access
+
 
 # Smallrye Health UI is disabled by default in production environment
 %prod.quarkus.smallrye-health.ui.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -123,7 +123,7 @@ quarkus.oidc.authentication.java-script-auto-redirect=false
 # - Global policy: Authenticated + one of:
 #     User roles: exploit-iq-view, exploit-iq-prodsec, exploit-iq-admin
 #     Service accounts: ${exploitiq.security.service-account-roles}
-#       OpenShift: system:serviceaccounts:${NAMESPACE}:exploit-iq-sa, ...:pipeline
+#       OpenShift: system:serviceaccount:${NAMESPACE}:exploit-iq-sa, ...:pipeline
 #       Keycloak / external-idp: exploitiq-api-access
 # - Exceptions: Specific paths (logout, health, dev-ui) are permitted.
 # ==============================================================================
@@ -144,7 +144,7 @@ quarkus.http.auth.permission.management.policy=permit
 
 # Service-account roles (OIDC-provider agnostic): used for HTTP auth and to skip report owner verification.
 # Outside exploit-iq.* AppConfig mapping so native builds do not bake unresolved ${NAMESPACE}.
-exploitiq.security.service-account-roles=system:serviceaccounts:${NAMESPACE}:exploit-iq-sa,system:serviceaccounts:${NAMESPACE}:pipeline,exploitiq-api-access
+exploitiq.security.service-account-roles=system:serviceaccount:${NAMESPACE}:exploit-iq-sa,system:serviceaccount:${NAMESPACE}:pipeline,exploitiq-api-access
 
 # Global policy: Require authentication and at least one role
 quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,system:serviceaccount:${NAMESPACE}:exploit-iq-sa,system:serviceaccount:${NAMESPACE}:pipeline,exploitiq-api-access

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -147,7 +147,7 @@ quarkus.http.auth.permission.management.policy=permit
 exploitiq.security.service-account-roles=system:serviceaccount:${NAMESPACE}:exploit-iq-sa,system:serviceaccount:${NAMESPACE}:pipeline,exploitiq-api-access
 
 # Global policy: Require authentication and at least one role
-quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,system:serviceaccount:${NAMESPACE}:exploit-iq-sa,system:serviceaccount:${NAMESPACE}:pipeline,exploitiq-api-access
+quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,${exploitiq.security.service-account-roles}
 quarkus.http.auth.permission.default.paths=/*
 quarkus.http.auth.permission.default.policy=role-policy
 # No order specified = lowest priority (applied last, after exceptions)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -150,8 +150,9 @@ quarkus.http.auth.permission.default.policy=role-policy
 # No order specified = lowest priority (applied last, after exceptions)
 
 # Service-account roles used to skip report owner verification (OIDC-provider agnostic).
+# Outside exploit-iq.* AppConfig mapping so native builds do not bake unresolved ${NAMESPACE}.
 # Keep in sync with the SA entries in role-policy.roles-allowed above.
-exploit-iq.security.service-account-roles=system:serviceaccounts:${NAMESPACE}:exploit-iq-sa,system:serviceaccounts:${NAMESPACE}:pipeline,exploitiq-api-access
+exploitiq.security.service-account-roles=system:serviceaccounts:${NAMESPACE:local-dev}:exploit-iq-sa,system:serviceaccounts:${NAMESPACE:local-dev}:pipeline,exploitiq-api-access
 
 
 # Smallrye Health UI is disabled by default in production environment

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -144,7 +144,7 @@ quarkus.http.auth.permission.management.policy=permit
 
 # Service-account roles (OIDC-provider agnostic): used for HTTP auth and to skip report owner verification.
 # Outside exploit-iq.* AppConfig mapping so native builds do not bake unresolved ${NAMESPACE}.
-exploitiq.security.service-account-roles=system:serviceaccounts:${NAMESPACE:local-dev}:exploit-iq-sa,system:serviceaccounts:${NAMESPACE:local-dev}:pipeline,exploitiq-api-access
+exploitiq.security.service-account-roles=system:serviceaccounts:${NAMESPACE}:exploit-iq-sa,system:serviceaccounts:${NAMESPACE}:pipeline,exploitiq-api-access
 
 # Global policy: Require authentication and at least one role
 quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,system:serviceaccount:${NAMESPACE}:exploit-iq-sa,system:serviceaccount:${NAMESPACE}:pipeline,exploitiq-api-access

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -122,10 +122,9 @@ quarkus.oidc.authentication.java-script-auto-redirect=false
 # Strategy:
 # - Global policy: Authenticated + one of:
 #     User roles: exploit-iq-view, exploit-iq-prodsec, exploit-iq-admin
-#     OpenShift SAs (specific only — not all SAs in the namespace):
-#       system:serviceaccounts:${NAMESPACE}:exploit-iq-sa  (ExploitIQ agent)
-#       system:serviceaccounts:${NAMESPACE}:pipeline       (CI / MLOps pipelines)
-#     External IdP / Keycloak service accounts: exploitiq-api-access
+#     Service accounts: ${exploitiq.security.service-account-roles}
+#       OpenShift: system:serviceaccounts:${NAMESPACE}:exploit-iq-sa, ...:pipeline
+#       Keycloak / external-idp: exploitiq-api-access
 # - Exceptions: Specific paths (logout, health, dev-ui) are permitted.
 # ==============================================================================
 
@@ -143,16 +142,15 @@ quarkus.http.auth.permission.management.policy=permit
 %dev.quarkus.http.auth.permission.dev-ui.paths=/q/*
 %dev.quarkus.http.auth.permission.dev-ui.policy=permit
 
+# Service-account roles (OIDC-provider agnostic): used for HTTP auth and to skip report owner verification.
+# Outside exploit-iq.* AppConfig mapping so native builds do not bake unresolved ${NAMESPACE}.
+exploitiq.security.service-account-roles=system:serviceaccounts:${NAMESPACE:local-dev}:exploit-iq-sa,system:serviceaccounts:${NAMESPACE:local-dev}:pipeline,exploitiq-api-access
+
 # Global policy: Require authentication and at least one role
 quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,system:serviceaccount:${NAMESPACE}:exploit-iq-sa,system:serviceaccount:${NAMESPACE}:pipeline,exploitiq-api-access
 quarkus.http.auth.permission.default.paths=/*
 quarkus.http.auth.permission.default.policy=role-policy
 # No order specified = lowest priority (applied last, after exceptions)
-
-# Service-account roles used to skip report owner verification (OIDC-provider agnostic).
-# Outside exploit-iq.* AppConfig mapping so native builds do not bake unresolved ${NAMESPACE}.
-# Keep in sync with the SA entries in role-policy.roles-allowed above.
-exploitiq.security.service-account-roles=system:serviceaccounts:${NAMESPACE:local-dev}:exploit-iq-sa,system:serviceaccounts:${NAMESPACE:local-dev}:pipeline,exploitiq-api-access
 
 
 # Smallrye Health UI is disabled by default in production environment

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceAuditTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceAuditTest.java
@@ -5,7 +5,6 @@
 
 package com.redhat.ecosystemappeng.exploitiq.service;
 
-import com.redhat.ecosystemappeng.exploitiq.config.AppConfig;
 import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditOperation;
 import com.redhat.ecosystemappeng.exploitiq.repository.ReportAuditRepositoryService;
 import io.quarkus.security.runtime.QuarkusPrincipal;
@@ -14,6 +13,7 @@ import io.quarkus.security.ForbiddenException;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.SecurityContext;
 import org.bson.Document;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -34,8 +34,8 @@ class ReportServiceAuditTest {
     @Inject
     ReportAuditRepositoryService auditRepository;
 
-    @Inject
-    AppConfig appConfig;
+    @ConfigProperty(name = "exploitiq.security.service-account-roles")
+    Set<String> serviceAccountRoles;
 
     @Test
     void removeSingleWritesAuditRecord() {
@@ -80,9 +80,6 @@ class ReportServiceAuditTest {
 
     @Test
     void markFailedByScanIdAllowsServiceAccountForForeignOwner() {
-        Set<String> serviceAccountRoles = appConfig.security()
-            .map(AppConfig.Security::serviceAccountRoles)
-            .orElse(Set.of());
         Assertions.assertFalse(serviceAccountRoles.isEmpty(), "service-account-roles must be configured");
         String serviceRole = serviceAccountRoles.iterator().next();
         long before = auditRepository.countDocuments();

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceAuditTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceAuditTest.java
@@ -5,6 +5,7 @@
 
 package com.redhat.ecosystemappeng.exploitiq.service;
 
+import com.redhat.ecosystemappeng.exploitiq.config.AppConfig;
 import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditOperation;
 import com.redhat.ecosystemappeng.exploitiq.repository.ReportAuditRepositoryService;
 import io.quarkus.security.runtime.QuarkusPrincipal;
@@ -16,6 +17,8 @@ import org.bson.Document;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import java.util.Set;
 
 @QuarkusTest
 class ReportServiceAuditTest {
@@ -30,6 +33,9 @@ class ReportServiceAuditTest {
 
     @Inject
     ReportAuditRepositoryService auditRepository;
+
+    @Inject
+    AppConfig appConfig;
 
     @Test
     void removeSingleWritesAuditRecord() {
@@ -47,7 +53,7 @@ class ReportServiceAuditTest {
     @Test
     void markFailedByScanIdAllowsOwnerInDevMode() {
         long before = auditRepository.countDocuments();
-        SecurityContext securityContext = devSecurityContext();
+        SecurityContext securityContext = humanSecurityContext();
 
         reportService.markFailedByScanId(
             ANONYMOUS_OWNED_SCAN_ID, "processing-error", "owner allowed", "anonymous", securityContext);
@@ -62,7 +68,7 @@ class ReportServiceAuditTest {
     @Test
     void markFailedByScanIdRejectsForeignOwner() {
         long before = auditRepository.countDocuments();
-        SecurityContext securityContext = devSecurityContext();
+        SecurityContext securityContext = humanSecurityContext();
 
         Assertions.assertThrows(
             ForbiddenException.class,
@@ -72,9 +78,38 @@ class ReportServiceAuditTest {
         Assertions.assertEquals(before, auditRepository.countDocuments());
     }
 
-    private static SecurityContext devSecurityContext() {
+    @Test
+    void markFailedByScanIdAllowsServiceAccountForForeignOwner() {
+        Set<String> serviceAccountRoles = appConfig.security()
+            .map(AppConfig.Security::serviceAccountRoles)
+            .orElse(Set.of());
+        Assertions.assertFalse(serviceAccountRoles.isEmpty(), "service-account-roles must be configured");
+        String serviceRole = serviceAccountRoles.iterator().next();
+        long before = auditRepository.countDocuments();
+        SecurityContext securityContext = serviceAccountSecurityContext(serviceRole);
+
+        reportService.markFailedByScanId(
+            FOREIGN_OWNED_SCAN_ID, "processing-error", "service account allowed", "exploit-iq-sa", securityContext);
+
+        Assertions.assertEquals(before + 1, auditRepository.countDocuments());
+        Document audit = auditRepository.findLatestByOperation(ReportAuditOperation.MODIFY_STATUS);
+        Assertions.assertNotNull(audit);
+        Assertions.assertEquals("exploit-iq-sa", audit.getString("actor"));
+        Assertions.assertEquals(
+            FOREIGN_OWNED_SCAN_ID, audit.get("context", Document.class).getString("scanId"));
+    }
+
+    private static SecurityContext humanSecurityContext() {
         SecurityContext securityContext = Mockito.mock(SecurityContext.class);
         Mockito.when(securityContext.getUserPrincipal()).thenReturn(new QuarkusPrincipal("anonymous"));
+        Mockito.when(securityContext.isUserInRole(Mockito.anyString())).thenReturn(false);
+        return securityContext;
+    }
+
+    private static SecurityContext serviceAccountSecurityContext(String serviceRole) {
+        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+        Mockito.when(securityContext.getUserPrincipal()).thenReturn(new QuarkusPrincipal("exploit-iq-sa"));
+        Mockito.when(securityContext.isUserInRole(serviceRole)).thenReturn(true);
         return securityContext;
     }
 }


### PR DESCRIPTION
## Summary
- Fix `POST /api/v1/reports/failed` owner verification on Keycloak (`external-idp`): stop using `instanceof JsonWebToken` to tell humans from service accounts.
- Detect service accounts via configured roles (`exploitiq.security.service-account-roles`), so ownership checks work across OpenShift OAuth and Keycloak.
- Cover SA bypass in `ReportServiceAuditTest`.

## Problem
`requiresOwnerVerification()` treated any JWT principal as a service account. That works on OpenShift OAuth (only SAs use JWTs), but on Keycloak both humans and SAs use JWTs — so owner verification was skipped for everyone, and any authenticated user could mark another user's reports as failed.

## Fix
Replace JWT-type coupling with a role check against configured service-account roles (`@ConfigProperty`, outside the `exploit-iq.*` `AppConfig` mapping so native builds do not resolve `${NAMESPACE}` at image-build time):
- OpenShift: `system:serviceaccounts:${NAMESPACE}:exploit-iq-sa`, `...:pipeline`
- Keycloak: `exploitiq-api-access`
Human callers still require `metadata.user` to match the actor; SA-role callers skip ownership checks.


[Jira](https://redhat.atlassian.net/issues?filter=-1&selectedIssue=APPENG-5788)