### PR TITLE
hotfix: fix 403 forbidden regression on agent->client communication

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/config/AppConfig.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/config/AppConfig.java
@@ -39,23 +39,12 @@ public interface AppConfig {
     Optional<Database> database();
     Optional<Audit> audit();
     Optional<SseConfig> sse();
-//    Security security();
 
     interface SseConfig {
         @WithName("heartbeat-interval")
         Duration heartbeatInterval();
     }
 
-    //    exploit-iq.security.target-roles
-
-//    interface Security {
-//        @WithName("target-roles")
-//        @Size(min = 1, max = 7)
-//        List<@NotBlank String> roles();
-
-//    }
-
-//    exploit-iq.image.source.location-keys
     interface Image {
         Source source();
         interface Source {
@@ -135,5 +124,4 @@ public interface AppConfig {
             }
         }
     }
-
 }

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/config/AppConfig.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/config/AppConfig.java
@@ -39,12 +39,23 @@ public interface AppConfig {
     Optional<Database> database();
     Optional<Audit> audit();
     Optional<SseConfig> sse();
+//    Security security();
 
     interface SseConfig {
         @WithName("heartbeat-interval")
         Duration heartbeatInterval();
     }
 
+    //    exploit-iq.security.target-roles
+
+//    interface Security {
+//        @WithName("target-roles")
+//        @Size(min = 1, max = 7)
+//        List<@NotBlank String> roles();
+
+//    }
+
+//    exploit-iq.image.source.location-keys
     interface Image {
         Source source();
         interface Source {
@@ -124,4 +135,5 @@ public interface AppConfig {
             }
         }
     }
+
 }

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentor.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentor.java
@@ -54,7 +54,7 @@ public class RoleMappingAugmentor implements SecurityIdentityAugmentor {
     @ConfigProperty(name = "quarkus.oidc.client-id", defaultValue = "exploit-iq-client")
     String clientId;
 
-    @ConfigProperty(name = "exploit-iq.security.target-roles", defaultValue = "exploit-iq-admin,exploit-iq-view,exploit-iq-prodsec")
+    @ConfigProperty(name = "quarkus.http.auth.policy.role-policy.roles-allowed", defaultValue = "exploit-iq-admin,exploit-iq-view,exploit-iq-prodsec")
     Set<String> targetRoles;
 
     @ConfigProperty(name = "quarkus.oidc.enabled", defaultValue = "true")

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentor.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentor.java
@@ -30,7 +30,9 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jboss.logging.Logger;
 
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -51,6 +53,10 @@ import java.util.Set;
 public class RoleMappingAugmentor implements SecurityIdentityAugmentor {
 
     private static final Logger LOG = Logger.getLogger(RoleMappingAugmentor.class);
+    public static final String KUBERNETES_IO_CLAIM_NAME = "kubernetes.io";
+    public static final String SERVICE_ACCOUNT_FIELD_NAME_IN_JWT = "serviceaccount";
+    public static final String NAME_OF_SERVICE_ACCOUNT_FIELD_NAME_IN_JWT = "name";
+    public static final String SERVICE_ACCOUNT_FULL_NAME_SUBJECT = "sub";
     @ConfigProperty(name = "quarkus.oidc.client-id", defaultValue = "exploit-iq-client")
     String clientId;
 
@@ -105,8 +111,36 @@ public class RoleMappingAugmentor implements SecurityIdentityAugmentor {
 
             LOG.debugf("Augmenting identity for principal: %s", identity.getPrincipal().getName());
 
-            checkClaimAndMapRoles(jwt.getClaim("groups"), "OpenShift Group", addedRoles, builder);
+            Object groupsObject = jwt.getClaim("groups");
+            checkClaimAndMapRoles(groupsObject, "OpenShift Group", addedRoles, builder);
+//            If no groups claim, fallback to search for principal is a K8 service account ( ServiceAccountFullName -> Authorized Role Mapping)
+            if (Objects.isNull(groupsObject) || (groupsObject instanceof Collection groups && groups.isEmpty()))
+            {
+//                Check if k8 JWT Service account , and if so, map service account name to role, if the sa role name is authorized
+                if (jwt.getClaim(KUBERNETES_IO_CLAIM_NAME) instanceof JsonObject k8Object) {
+                    try {
 
+                        var serviceAccountJsonObject = k8Object.getJsonObject(SERVICE_ACCOUNT_FIELD_NAME_IN_JWT);
+                        var serviceAccountName = serviceAccountJsonObject.getJsonString(NAME_OF_SERVICE_ACCOUNT_FIELD_NAME_IN_JWT).getString().trim();
+//                        This is a JWT of K8 service account, now check if it's in allowed roles and if so, add it as authorized service account
+                        if (!serviceAccountName.isEmpty()) {
+                            String fullSaName = jwt.getClaim(SERVICE_ACCOUNT_FULL_NAME_SUBJECT);
+                            if (!fullSaName.isEmpty() && targetRoles.contains(fullSaName)) {
+                                processRole(fullSaName,"full_service_account_name_jwt_k8",addedRoles , builder);
+                                LOG.infof("Granted permission to K8 ServiceAccount: %s based on configured Authorized roles", identity.getPrincipal().getName());
+                            }
+                            else {
+                                LOG.infof("Permission denied for K8 ServiceAccount: %s, authorization mapping rule to an authorized role doesn't exist", identity.getPrincipal().getName());
+                            }
+                        }
+                    } catch (Exception e) {
+
+                        LOG.errorf(e,"Couldn't verify k8 service account for principal: %s, continues to other possible paths in JWT.", identity.getPrincipal().getName());
+                    }
+
+
+                }
+            }
             Object realmAccessObj = jwt.getClaim("realm_access");
             if (realmAccessObj instanceof JsonObject) {
                 JsonObject realmAccess = (JsonObject) realmAccessObj;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -143,8 +143,11 @@ quarkus.http.auth.permission.management.policy=permit
 %dev.quarkus.http.auth.permission.dev-ui.paths=/q/*
 %dev.quarkus.http.auth.permission.dev-ui.policy=permit
 
+
+
+#exploit-iq.security.target-roles=exploit-iq-admin,exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,system:serviceaccount:${NAMESPACE}:exploit-iq-sa,system:serviceaccount:${NAMESPACE}:pipeline,exploitiq-api-access
 # Global policy: Require authentication and at least one role
-quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,system:serviceaccounts:${NAMESPACE}:exploit-iq-sa,system:serviceaccounts:${NAMESPACE}:pipeline,exploitiq-api-access
+quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,system:serviceaccount:${NAMESPACE}:exploit-iq-sa,system:serviceaccount:${NAMESPACE}:pipeline,exploitiq-api-access
 quarkus.http.auth.permission.default.paths=/*
 quarkus.http.auth.permission.default.policy=role-policy
 # No order specified = lowest priority (applied last, after exceptions)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -143,9 +143,6 @@ quarkus.http.auth.permission.management.policy=permit
 %dev.quarkus.http.auth.permission.dev-ui.paths=/q/*
 %dev.quarkus.http.auth.permission.dev-ui.policy=permit
 
-
-
-#exploit-iq.security.target-roles=exploit-iq-admin,exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,system:serviceaccount:${NAMESPACE}:exploit-iq-sa,system:serviceaccount:${NAMESPACE}:pipeline,exploitiq-api-access
 # Global policy: Require authentication and at least one role
 quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,system:serviceaccount:${NAMESPACE}:exploit-iq-sa,system:serviceaccount:${NAMESPACE}:pipeline,exploitiq-api-access
 quarkus.http.auth.permission.default.paths=/*


### PR DESCRIPTION
 
##  Background

  ProdSec requires that only a curated list of service accounts (e.g., the agent SA, the pipeline SA for CI builds) be authorized to access the Client API. Previously, all service accounts in the namespace had
  unrestricted access — meaning any compromised pod with an arbitrary service account could post fabricated or manipulated analysis results to the database via the API (see threat item APPENG-5705).

##  What Happened

  Our authorization model maps user groups to roles (1:1 match). If the mapped role appears in the allow list, the request's user token or service account JWT is authorized.

  Previously, system:serviceaccounts:${NAMESPACE} was configured as an authorized role. This worked because in OpenShift, every service account in a namespace automatically belongs to the groups
  system:serviceaccounts and `system:serviceaccounts:<namespace>`. The augmentor mapped these groups to the authorized role, effectively granting access to all SAs in the namespace.

  After tightening the configuration to use individual service account full names as authorized roles (e.g., system:serviceaccount:<namespace>:exploit-iq-sa), these names no longer correspond to any OpenShift
  group. The SA's only group memberships remain the broad system:serviceaccounts and system:serviceaccounts:<namespace> groups, which no longer match any allowed role — resulting in 403 Forbidden.

  Additionally, the role names contained a typo: system:serviceaccounts (plural) instead of the correct Kubernetes form system:serviceaccount (singular).

##  Solution

  Added a new mapping path in the RoleMappingAugmentor, alongside the existing Keycloak role-to-role and OpenShift group-to-role mappers:

  - When a JWT has no groups claim (or it is empty), the augmentor inspects the kubernetes.io claim to identify K8s service account tokens.
  - It extracts the full service account name from the sub claim and checks it against the configured allowed roles.
  - If the name matches an allowed role, the SA is granted access; otherwise, a 403 is returned.

  This ensures only explicitly authorized service accounts can access the API, satisfying the ProdSec requirement.