### PR TITLE
fix(queue): admit before persist so 429 leaves no orphan reports

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpoint.java
@@ -179,15 +179,15 @@ public class ReportEndpoint {
         }
       }
 
-      ReportData res = reportService.process(request);
+      ReportData generated = reportService.generateReport(request);
 
-      if (Objects.nonNull(credentialId) && Objects.nonNull(res.report())) {
-        credentialProcessingService.injectCredentialId(res.report(), credentialId);
+      if (Objects.nonNull(credentialId) && Objects.nonNull(generated.report())) {
+        credentialProcessingService.injectCredentialId(generated.report(), credentialId);
       }
 
-      if (sendToExploitIq) {
-        reportService.submit(res.reportRequestId().id(), res.report());
-      }
+      ReportData res = sendToExploitIq
+          ? reportService.saveAndSubmitNew(generated)
+          : reportService.saveReport(generated);
 
       return Response.accepted(res).build();
     } catch (IllegalArgumentException e) {

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ComponentProcessingService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ComponentProcessingService.java
@@ -137,11 +137,14 @@ public class ComponentProcessingService {
         // Try to save report and submit via reportService (queue for analysis)
         ReportData savedReportData = null;
         try {
-            savedReportData = reportService.saveReport(reportData);
-            String reportId = savedReportData.reportRequestId().reportId();
-            LOGGER.infof("Saved report %s to repository for component: %s", reportId, component.name());
-            reportService.submit(savedReportData.reportRequestId().id(), savedReportData.report());
-            LOGGER.infof("Submitted report %s for analysis (component: %s)", reportId, component.name());
+            savedReportData = reportService.saveAndSubmitNew(reportData);
+            LOGGER.infof("Saved and submitted report %s for analysis (component: %s)",
+                savedReportData.reportRequestId().reportId(), component.name());
+        } catch (RequestQueueExceededException e) {
+            LOGGER.errorf("Queue full for component %s: no report persisted", component.name());
+            productRepositoryService.addSubmissionFailure(productId, new FailedComponent(
+                component.name(), component.version(), component.image(),
+                "Too Many Parallel Requests"));
         } catch (Exception e) {
             // Post-save failure: error during save or submit - update report or submissionFailures
             if (savedReportData != null) {

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
@@ -397,9 +397,9 @@ public class ReportService {
     if(Objects.isNull(report)) {
       return false;
     }
-    repository.setAsRetried(id, userService.getUserName());
     LOGGER.debugf("Retry report %s", id);
-    queueService.queue(id, objectMapper.readTree(report));
+    queueService.admit(id, objectMapper.readTree(report),
+        () -> repository.setAsRetried(id, userService.getUserName()));
 
     return true;
   }
@@ -515,9 +515,31 @@ public class ReportService {
 
   public void submit(String id, JsonNode report) throws JsonProcessingException, IOException {
     String byUser = determineUser(report);
-    repository.setAsSubmitted(id, byUser);
-    queueService.queue(id, report);
+    queueService.admit(id, report, () -> repository.setAsSubmitted(id, byUser));
     LOGGER.infof("Request ID: %s, sent to ExploitIQ for analysis", id);
+  }
+
+  /**
+   * Persists and submits a new report only if the queue has capacity.
+   * Full queue → {@link RequestQueueExceededException} and no Mongo write.
+   */
+  public ReportData saveAndSubmitNew(ReportData reportData) throws JsonProcessingException, IOException {
+    try {
+      return queueService.runIfHasCapacity(() -> {
+        try {
+          ReportData saved = saveReport(reportData);
+          submit(saved.reportRequestId().id(), saved.report());
+          return saved;
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      });
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof IOException ioe) {
+        throw ioe;
+      }
+      throw e;
+    }
   }
 
   private String determineUser(JsonNode report) {

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
@@ -19,9 +19,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.Objects;
 
-import com.redhat.ecosystemappeng.exploitiq.client.ExploitIqService;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
@@ -114,33 +112,32 @@ public class RequestQueueService {
   }
 
   private void moveToActive() {
-
-    // prevent thread blocked exceptions and a lot of Polled null values from the pending queue messages.
-    while (pending.size() > 0 && active.size() < maxActive) {
-      submitOneReportFromQueue();
+    String nextId;
+    while ((nextId = pollPendingIfCapacity()) != null) {
+      submitOneReportFromQueue(nextId);
     }
   }
 
-  private void submitOneReportFromQueue() {
-
-    var nextId = pending.poll();
-    if (Objects.isNull(nextId)) {
-      return;
+  private synchronized String pollPendingIfCapacity() {
+    if (pending.isEmpty() || active.size() >= maxActive) {
+      return null;
     }
+    return pending.poll();
+  }
+
+  private void submitOneReportFromQueue(String nextId) {
     Span span = tracer.spanBuilder("internal queue processing submit one former pending")
             .setSpanKind(SpanKind.INTERNAL)
             .startSpan();
     var report = repository.findById(nextId);
-
     LOGGER.debugf("Polled %s from the pending queue", nextId);
-    if (Objects.nonNull(report)) {
+    if (report != null) {
       try {
-
         JsonNode jsonReport = objectMapper.readTree(report);
         MDC.put(TRACE_ID, jsonReport.get("input").get("scan").get("id").textValue());
         MDC.put(SPAN_ID, span.getSpanContext().getSpanId());
         LOGGER.debugf("Submit report %s", nextId);
-        submit(nextId, jsonReport);
+        admit(nextId, jsonReport, () -> {});
       } catch (JsonProcessingException e) {
         LOGGER.error("Unable to submit request", e);
         repository.updateWithError(nextId, "json-processing-error", e.getMessage());
@@ -149,27 +146,46 @@ public class RequestQueueService {
     span.end();
   }
 
-  public void queue(String id, JsonNode json) {
-    if (active.size() >= maxActive) {
-      if (pending.size() >= maxSize) {
-        throw new RequestQueueExceededException(maxSize);
+  public void admit(String id, JsonNode json, Runnable onAdmitted) {
+    boolean sendNow;
+    synchronized (this) {
+      if (active.size() >= maxActive) {
+        if (pending.size() >= maxSize) {
+          throw new RequestQueueExceededException(maxSize);
+        }
+        pending.add(id);
+        sendNow = false;
+      } else {
+        active.put(id, LocalDateTime.now());
+        sendNow = true;
       }
-      LOGGER.debugf("Added %s to pending queue", id);
-      pending.add(id);
-    } else {
+    }
+    onAdmitted.run();
+    if (sendNow) {
       LOGGER.debugf("Submit report %s", id);
-      submit(id, json);
+      sendToExploitIq(id, json);
+    } else {
+      LOGGER.debugf("Added %s to pending queue", id);
     }
   }
 
-  private void submit(String id, JsonNode report) {
+  public <T> T runIfHasCapacity(java.util.function.Supplier<T> action) {
+    synchronized (this) {
+      if (active.size() >= maxActive && pending.size() >= maxSize) {
+        throw new RequestQueueExceededException(maxSize);
+      }
+    }
+    return action.get();
+  }
+
+  private void sendToExploitIq(String id, JsonNode report) {
     try {
       exploitIqService.submitAsync(report.get("input").toPrettyString());
       repository.setAsSent(id);
-      active.put(id, LocalDateTime.now());
       LOGGER.debugf("Report %s sent to ExploitIQ", id);
     } catch (Exception e) {
       LOGGER.error("Unable to submit request", e);
+      active.remove(id);
       repository.updateWithError(id, "exploit-iq-request-error", e.getMessage());
     }
   }

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RpmReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RpmReportService.java
@@ -65,9 +65,7 @@ public class RpmReportService {
       throws JsonProcessingException, IOException {
     ValidatedNewRpmReport v = validateNewRpmReportRequest(request);
     ReportData reportData = generateRpmPackageCheckerReport(v);
-    ReportData saved = reportService.saveReport(reportData);
-    reportService.submit(saved.reportRequestId().id(), saved.report());
-    return saved;
+    return reportService.saveAndSubmitNew(reportData);
   }
 
   private ValidatedNewRpmReport validateNewRpmReportRequest(NewRpmReportRequest request) throws ValidationException {

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/SbomReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/SbomReportService.java
@@ -154,7 +154,8 @@ public class SbomReportService {
       credentialProcessingService.injectCredentialId(reportData.report(), credentialId);
     }
 
-    ReportData savedReportData = reportService.saveReport(reportData);
+    // Capacity gate first (inside saveAndSubmitNew): 429 → no report and no product.
+    ReportData savedReportData = reportService.saveAndSubmitNew(reportData);
     Product product =
         newProductDocument(
             cveId,
@@ -164,9 +165,6 @@ public class SbomReportService {
             CYCLONEDX_COMPONENT_COUNT,
             new HashMap<>());
     productRepository.save(product, userService.getUserName());
-    // If submit fails after this point, the report and product exist but the request was not queued;
-    // callers surface the error and operational cleanup is out of scope for this flow.
-    reportService.submit(savedReportData.reportRequestId().id(), savedReportData.report());
     return savedReportData;
   }
 

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceCredentialInjectionOrderTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceCredentialInjectionOrderTest.java
@@ -65,7 +65,7 @@ class ReportServiceCredentialInjectionOrderTest {
 
     Mockito.when(cycloneDxParsingService.parseCycloneDxFile(any())).thenReturn(parsedCycloneDx);
     Mockito.when(reportService.createCycloneDxReportData(any(), any(), any(), eq(false))).thenReturn(reportData);
-    Mockito.when(reportService.saveReport(any())).thenReturn(savedReportData);
+    Mockito.when(reportService.saveAndSubmitNew(any())).thenReturn(savedReportData);
     Mockito.when(userService.getUserName()).thenReturn("test-user");
   }
 
@@ -76,10 +76,9 @@ class ReportServiceCredentialInjectionOrderTest {
     InOrder inOrder = Mockito.inOrder(credentialProcessingService, reportService, productRepository);
     assertDoesNotThrow(() -> {
       inOrder.verify(credentialProcessingService).injectCredentialId(any(JsonNode.class), eq(CREDENTIAL_ID));
-      inOrder.verify(reportService).saveReport(any());
+      inOrder.verify(reportService).saveAndSubmitNew(any());
       inOrder.verify(productRepository).save(any(Product.class), any());
-      inOrder.verify(reportService).submit(any(), any(JsonNode.class));
-    }, "credentialId must be injected BEFORE saveReport() and submit(), " +
+    }, "credentialId must be injected BEFORE saveAndSubmitNew(), " +
        "otherwise it is not persisted in MongoDB and not included in the ExploitIQ payload");
   }
 
@@ -89,9 +88,8 @@ class ReportServiceCredentialInjectionOrderTest {
 
     InOrder inOrder = Mockito.inOrder(reportService, productRepository);
     Mockito.verify(credentialProcessingService, Mockito.never()).injectCredentialId(any(), any());
-    inOrder.verify(reportService).saveReport(any());
+    inOrder.verify(reportService).saveAndSubmitNew(any());
     inOrder.verify(productRepository).save(any(Product.class), any());
-    inOrder.verify(reportService).submit(any(), any(JsonNode.class));
   }
 
   @Test
@@ -100,8 +98,7 @@ class ReportServiceCredentialInjectionOrderTest {
         () -> sbomReportService.submitCycloneDx("INVALID", new ByteArrayInputStream(new byte[0]), CREDENTIAL_ID));
 
     Mockito.verify(credentialProcessingService, Mockito.never()).injectCredentialId(any(), any());
-    Mockito.verify(reportService, Mockito.never()).saveReport(any());
+    Mockito.verify(reportService, Mockito.never()).saveAndSubmitNew(any());
     Mockito.verify(productRepository, Mockito.never()).save(any(), any());
-    Mockito.verify(reportService, Mockito.never()).submit(any(), any());
   }
 }

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceQueueAdmissionTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceQueueAdmissionTest.java
@@ -1,0 +1,156 @@
+package com.redhat.ecosystemappeng.exploitiq.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.redhat.ecosystemappeng.exploitiq.config.AppConfig;
+import com.redhat.ecosystemappeng.exploitiq.model.ReportData;
+import com.redhat.ecosystemappeng.exploitiq.model.ReportRequestId;
+import com.redhat.ecosystemappeng.exploitiq.repository.ProductRepositoryService;
+import com.redhat.ecosystemappeng.exploitiq.repository.ReportAuditRepositoryService;
+import com.redhat.ecosystemappeng.exploitiq.repository.ReportRepositoryService;
+import com.redhat.ecosystemappeng.exploitiq.rest.NotificationSocket;
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@QuarkusComponentTest
+class ReportServiceQueueAdmissionTest {
+
+  @Inject
+  ReportService reportService;
+
+  @InjectMock
+  ReportRepositoryService repository;
+  @InjectMock
+  ProductService productService;
+  @InjectMock
+  RequestQueueService queueService;
+  @InjectMock
+  UserService userService;
+  @InjectMock
+  ObjectMapper objectMapper;
+
+  // Other ReportService dependencies mocked to keep component wiring stable.
+  @InjectMock
+  AppConfig appConfig;
+  @InjectMock
+  ProductRepositoryService productRepository;
+  @InjectMock
+  NotificationSocket notificationSocket;
+  @InjectMock
+  ReportAuditService reportAuditService;
+  @InjectMock
+  ReportAuditRepositoryService reportAuditRepositoryService;
+  @InjectMock
+  Scheduler scheduler;
+  @InjectMock
+  @RestClient
+  com.redhat.ecosystemappeng.exploitiq.client.GitHubService gitHubService;
+
+  @Test
+  void submitHappyPathWritesSubmittedAfterAdmission() throws Exception {
+    ObjectNode report = new ObjectMapper().createObjectNode();
+    report.set("metadata", new ObjectMapper().createObjectNode());
+    when(userService.getUserName()).thenReturn("alice");
+
+    doAnswer(invocation -> {
+      Runnable onAdmitted = invocation.getArgument(2);
+      onAdmitted.run();
+      return null;
+    }).when(queueService).admit(eq("id-1"), eq(report), any(Runnable.class));
+
+    reportService.submit("id-1", report);
+
+    verify(repository).setAsSubmitted("id-1", "alice");
+    verify(queueService).admit(eq("id-1"), eq(report), any(Runnable.class));
+  }
+
+  @Test
+  void submitUnhappyPathQueueFullDoesNotWriteSubmitted() {
+    ObjectNode report = new ObjectMapper().createObjectNode();
+    report.set("metadata", new ObjectMapper().createObjectNode());
+    when(userService.getUserName()).thenReturn("alice");
+    doThrow(new RequestQueueExceededException(2))
+        .when(queueService).admit(eq("id-2"), eq(report), any(Runnable.class));
+
+    assertThrows(RequestQueueExceededException.class, () -> reportService.submit("id-2", report));
+
+    verify(repository, never()).setAsSubmitted(eq("id-2"), eq("alice"));
+  }
+
+  @Test
+  void saveAndSubmitNewQueueFullDoesNotPersist() throws Exception {
+    ObjectNode report = new ObjectMapper().createObjectNode();
+    report.set("metadata", new ObjectMapper().createObjectNode());
+    ReportData unsaved = new ReportData(new ReportRequestId(null, "scan-x"), report);
+
+    doThrow(new RequestQueueExceededException(2))
+        .when(queueService).runIfHasCapacity(any());
+
+    assertThrows(RequestQueueExceededException.class, () -> reportService.saveAndSubmitNew(unsaved));
+
+    verify(repository, never()).save(any());
+    verify(queueService, never()).admit(any(), any(), any());
+  }
+
+  @Test
+  void retryHappyPathWritesRetriedOnlyAfterAdmission() throws Exception {
+    String reportJson = """
+        {"input":{"scan":{"id":"scan-1"}},"metadata":{}}
+        """;
+    JsonNode parsedReport = new ObjectMapper().readTree(reportJson);
+    when(repository.findById("id-3")).thenReturn(reportJson);
+    when(objectMapper.readTree(reportJson)).thenReturn(parsedReport);
+    when(userService.getUserName()).thenReturn("alice");
+    doAnswer(invocation -> {
+      Runnable onAdmitted = invocation.getArgument(2);
+      onAdmitted.run();
+      return null;
+    }).when(queueService).admit(eq("id-3"), any(), any(Runnable.class));
+
+    boolean retried = reportService.retry("id-3");
+
+    assertTrue(retried);
+    verify(repository).setAsRetried("id-3", "alice");
+  }
+
+  @Test
+  void retryUnhappyPathQueueFullDoesNotWriteRetried() throws Exception {
+    String reportJson = """
+        {"input":{"scan":{"id":"scan-2"}},"metadata":{}}
+        """;
+    JsonNode parsedReport = new ObjectMapper().readTree(reportJson);
+    when(repository.findById("id-4")).thenReturn(reportJson);
+    when(objectMapper.readTree(reportJson)).thenReturn(parsedReport);
+    doThrow(new RequestQueueExceededException(2))
+        .when(queueService).admit(eq("id-4"), any(), any(Runnable.class));
+
+    assertThrows(RequestQueueExceededException.class, () -> reportService.retry("id-4"));
+    verify(repository, never()).setAsRetried(eq("id-4"), any());
+  }
+
+  @Test
+  void retryUnhappyPathNotFoundReturnsFalse() throws Exception {
+    when(repository.findById("missing-id")).thenReturn(null);
+
+    boolean retried = reportService.retry("missing-id");
+
+    assertFalse(retried);
+    verify(queueService, never()).admit(any(), any(), any(Runnable.class));
+  }
+}


### PR DESCRIPTION
## Summary
- Check queue capacity before persisting new reports so a full queue returns 429 without writing MongoDB orphans.
- Admit only after capacity is available; mark submitted or retried only on successful admission.
- Reuse `saveAndSubmitNew` across create paths and add `ReportServiceQueueAdmissionTest` coverage.

## Test plan
- [ ] `./mvnw test -Dtest=ReportServiceQueueAdmissionTest`
- [ ] Manual: `max-active=2`, `max-size=2`, empty DB, submit 8 requests → 4×202 + 4×429, `total=4`, `queued=2`/`sent=2` match metrics
- [ ] Confirm rejected requests never appear in `GET /api/v1/reports`

A more detailed test plan is in the attachment.
[test-queue.md](https://github.com/user-attachments/files/30299301/test-queue.md)

Jira issue: https://redhat.atlassian.net/browse/TC-5344