### PR TITLE
APPENG-5698: add per-user concurrent request limiting to analysis queue

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,12 +48,19 @@ requests. Finally it is possible to define the timeout for an ongoing request.
 
 ```properties
 exploit-iq.queue.max-active=5 #max number of ongoing requests
+exploit-iq.queue.max-active-per-user=5 #max number of concurrent ongoing requests per authenticated user
 exploit-iq.queue.max-size=100 #max number of waiting requests
 exploit-iq.queue.timeout=5m #duration of an ongoing request
 ```
 
 Every 10 seconds the ongoing requests will be checked and expired if needed, then
 the waiting queue will be updated and send new requests to ExploitIQ
+
+`exploit-iq.queue.max-active-per-user` limits how many of the global `max-active`
+slots a single authenticated user can occupy at once. This prevents one user from
+submitting enough large requests to exhaust the entire queue and blocking other
+users. When a user reaches this limit, new requests are rejected immediately with
+HTTP 429, without affecting the global pending/active accounting for other users.
 
 ## Pending Component Syncer timeout
 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/config/AppConfig.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/config/AppConfig.java
@@ -64,6 +64,9 @@ public interface AppConfig {
         @WithName("max-active")
         int maxActive();
 
+        @WithName("max-active-per-user")
+        int maxActivePerUser();
+
         @WithName("max-size")
         Optional<Integer> maxSize();
 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/ProductEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/ProductEndpoint.java
@@ -53,6 +53,7 @@ import com.redhat.ecosystemappeng.exploitiq.service.SbomReportService;
 import com.redhat.ecosystemappeng.exploitiq.service.UserService;
 import com.redhat.ecosystemappeng.exploitiq.service.UtilitiesService;
 import com.redhat.ecosystemappeng.exploitiq.service.RequestQueueExceededException;
+import com.redhat.ecosystemappeng.exploitiq.service.UserQueueExceededException;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
@@ -407,6 +408,15 @@ public class ProductEndpoint {
     return Response.status(Response.Status.TOO_MANY_REQUESTS)
             .entity(objectMapper.createObjectNode()
                     .put("error", "Too many requests, limit exceeded"))
+            .build();
+  }
+
+  @ServerExceptionMapper
+  public Response mapUserQueueExceededException(UserQueueExceededException e) {
+    LOGGER.errorf("Per-user concurrent request limit exceeded");
+    return Response.status(Response.Status.TOO_MANY_REQUESTS)
+            .entity(objectMapper.createObjectNode()
+                    .put("error", "Per-user concurrent request limit exceeded"))
             .build();
   }
 }

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/ReportEndpoint.java
@@ -55,6 +55,7 @@ import com.redhat.ecosystemappeng.exploitiq.service.ProductService;
 import com.redhat.ecosystemappeng.exploitiq.service.ReportService;
 import com.redhat.ecosystemappeng.exploitiq.service.RpmReportService;
 import com.redhat.ecosystemappeng.exploitiq.service.RequestQueueExceededException;
+import com.redhat.ecosystemappeng.exploitiq.service.UserQueueExceededException;
 import com.redhat.ecosystemappeng.exploitiq.service.UserService;
 import com.redhat.ecosystemappeng.exploitiq.service.UtilitiesService;
 import com.redhat.ecosystemappeng.exploitiq.model.ReportAuditOperation;
@@ -199,11 +200,9 @@ public class ReportEndpoint {
       return Response.status(e.getResponse().getStatus())
         .entity(e.getResponse().getEntity())
         .build();
-    } catch (RequestQueueExceededException e) {
-      return Response.status(Status.TOO_MANY_REQUESTS)
-        .entity(objectMapper.createObjectNode()
-        .put("error", "Too many requests, limit exceeded"))
-        .build();
+    } catch (RequestQueueExceededException | UserQueueExceededException e) {
+      // Handled by the class-level @ServerExceptionMapper methods below.
+      throw e;
     } catch (Exception e) {
       LOGGER.error("Unable to process new analysis request", e);
       return Response.serverError()
@@ -253,12 +252,6 @@ public class ReportEndpoint {
     try {
       ReportData res = rpmReportService.persistAndSubmitNewRpmReport(request);
       return Response.accepted(res).build();
-    } catch (RequestQueueExceededException e) {
-      LOGGER.errorf("Too many requests, limit exceeded");
-      return Response.status(Status.TOO_MANY_REQUESTS)
-        .entity(objectMapper.createObjectNode()
-          .put("error", "Too many requests, limit exceeded"))
-        .build();
     } catch (IOException e) {
       LOGGER.error("Unable to persist or submit RPM analysis request", e);
       return Response.serverError()
@@ -703,11 +696,9 @@ public class ReportEndpoint {
       return Response.status(e.getResponse().getStatus())
         .entity(e.getResponse().getEntity())
         .build();
-    } catch (RequestQueueExceededException e) {
-      return Response.status(Status.TOO_MANY_REQUESTS)
-        .entity(objectMapper.createObjectNode()
-        .put("error", e.getMessage()))
-        .build();
+    } catch (RequestQueueExceededException | UserQueueExceededException e) {
+      // Handled by the class-level @ServerExceptionMapper methods below.
+      throw e;
     } catch (Exception e) {
       LOGGER.error("Unable to submit new analysis request", e);
       return Response.serverError()
@@ -971,6 +962,24 @@ public class ReportEndpoint {
     LOGGER.errorf("Unauthorized: %s", e.getMessage());
     return Response.status(Status.UNAUTHORIZED)
         .entity(objectMapper.createObjectNode().put("error", "Unauthorized"))
+        .build();
+  }
+
+  @ServerExceptionMapper
+  public Response mapQueueExceededException(RequestQueueExceededException e) {
+    LOGGER.errorf("Too many requests, limit exceeded");
+    return Response.status(Status.TOO_MANY_REQUESTS)
+        .entity(objectMapper.createObjectNode()
+            .put("error", "Too many requests, limit exceeded"))
+        .build();
+  }
+
+  @ServerExceptionMapper
+  public Response mapUserQueueExceededException(UserQueueExceededException e) {
+    LOGGER.errorf("Per-user concurrent request limit exceeded");
+    return Response.status(Status.TOO_MANY_REQUESTS)
+        .entity(objectMapper.createObjectNode()
+            .put("error", "Per-user concurrent request limit exceeded"))
         .build();
   }
 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ComponentProcessingService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ComponentProcessingService.java
@@ -174,6 +174,9 @@ public class ComponentProcessingService {
         if(e instanceof RequestQueueExceededException) {
             return String.format("%s: Too Many Parallel Requests", prefixMessage);
         }
+        if(e instanceof UserQueueExceededException) {
+            return String.format("%s: Too Many Parallel Requests For User", prefixMessage);
+        }
 //        Otherwise, return just a generic error message, could be looked up in logs what is the specific reason for failure/error.
         return prefixMessage;
     }

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
@@ -399,8 +399,16 @@ public class ReportService {
     }
     var user = userService.getUserName();
     LOGGER.debugf("Retry report %s", id);
-    queueService.admit(id, objectMapper.readTree(report), user,
-        () -> repository.setAsRetried(id, user));
+    try {
+      queueService.admit(id, objectMapper.readTree(report), user,
+          () -> repository.setAsRetried(id, user));
+    } catch (RequestQueueExceededException e) {
+      repository.updateWithError(id, "queue-exceeded", e.getMessage());
+      throw e;
+    } catch (UserQueueExceededException e) {
+      repository.updateWithError(id, "user-queue-exceeded", e.getMessage());
+      throw e;
+    }
 
     return true;
   }
@@ -516,7 +524,15 @@ public class ReportService {
 
   public void submit(String id, JsonNode report) throws JsonProcessingException, IOException {
     String byUser = determineUser(report);
-    queueService.admit(id, report, byUser, () -> repository.setAsSubmitted(id, byUser));
+    try {
+      queueService.admit(id, report, byUser, () -> repository.setAsSubmitted(id, byUser));
+    } catch (RequestQueueExceededException e) {
+      repository.updateWithError(id, "queue-exceeded", e.getMessage());
+      throw e;
+    } catch (UserQueueExceededException e) {
+      repository.updateWithError(id, "user-queue-exceeded", e.getMessage());
+      throw e;
+    }
     LOGGER.infof("Request ID: %s, sent to ExploitIQ for analysis", id);
   }
 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
@@ -539,10 +539,15 @@ public class ReportService {
   /**
    * Persists and submits a new report only if the queue has capacity.
    * Full queue → {@link RequestQueueExceededException} and no Mongo write.
+   * User over their concurrent-request limit → {@link UserQueueExceededException} and no Mongo
+   * write. The owning user is resolved up front (before any persistence) so the per-user check
+   * in {@link RequestQueueService#runIfHasCapacity} runs before {@link #saveReport}, keeping the
+   * "throws → nothing persisted" guarantee callers rely on.
    */
   public ReportData saveAndSubmitNew(ReportData reportData) throws JsonProcessingException, IOException {
+    String user = determineUser(reportData.report());
     try {
-      return queueService.runIfHasCapacity(() -> {
+      return queueService.runIfHasCapacity(user, () -> {
         try {
           ReportData saved = saveReport(reportData);
           submit(saved.reportRequestId().id(), saved.report());

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
@@ -397,9 +397,10 @@ public class ReportService {
     if(Objects.isNull(report)) {
       return false;
     }
+    var user = userService.getUserName();
     LOGGER.debugf("Retry report %s", id);
-    queueService.admit(id, objectMapper.readTree(report),
-        () -> repository.setAsRetried(id, userService.getUserName()));
+    queueService.admit(id, objectMapper.readTree(report), user,
+        () -> repository.setAsRetried(id, user));
 
     return true;
   }
@@ -515,7 +516,7 @@ public class ReportService {
 
   public void submit(String id, JsonNode report) throws JsonProcessingException, IOException {
     String byUser = determineUser(report);
-    queueService.admit(id, report, () -> repository.setAsSubmitted(id, byUser));
+    queueService.admit(id, report, byUser, () -> repository.setAsSubmitted(id, byUser));
     LOGGER.infof("Request ID: %s, sent to ExploitIQ for analysis", id);
   }
 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
@@ -316,11 +316,15 @@ public class RequestQueueService {
     active.put(id, sentAt);
     activeUserById.put(id, user);
     activeByUser.computeIfAbsent(user, k -> ConcurrentHashMap.newKeySet()).add(id);
+    LOGGER.debugf(
+        "[trackActive] active map: put id=%s -> sentAt=%s; activeUserById map: put id=%s -> user=%s; activeByUser map: added id=%s to user=%s set",
+        id, sentAt, id, user, id, user);
   }
 
   private void trackPending(String id, String user) {
     pending.add(new PendingRequest(id, user));
     pendingByUser.computeIfAbsent(user, k -> ConcurrentHashMap.newKeySet()).add(id);
+    LOGGER.debugf("[trackPending] pendingByUser map: added id=%s to user=%s set", id, user);
   }
 
   private void untrackPending(PendingRequest request) {
@@ -329,6 +333,7 @@ public class RequestQueueService {
       ids.remove(request.id());
       if (ids.isEmpty()) {
         pendingByUser.remove(request.user(), ids);
+        LOGGER.debugf("[untrackPending] pendingByUser map: removed id=%s from user=%s set (set now empty, user entry removed)", request.id(), request.user()); 
       }
     }
   }
@@ -357,6 +362,7 @@ public class RequestQueueService {
           ids.remove(id);
           if (ids.isEmpty()) {
             activeByUser.remove(user, ids);
+            LOGGER.debugf("[removeActive] activeByUser map: removed id=%s from user=%s set (set now empty, user entry removed)", id, user);     
           }
         }
       }

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
@@ -219,7 +219,7 @@ public class RequestQueueService {
    * and {@code onAdmitted} never runs.
    */
   public void admit(String id, JsonNode json, String user, Runnable onAdmitted) {
-    var effectiveUser = Objects.nonNull(user) && !user.isBlank() ? user : DEFAULT_USER;
+    var effectiveUser = resolveEffectiveUser(user);
     boolean sendNow;
     // The compound check-then-act below only touches this user's own state (activeByUser/
     // pendingByUser), so a per-user lock is sufficient - concurrent admission for other users
@@ -275,13 +275,37 @@ public class RequestQueueService {
     admit(id, json, user, () -> {});
   }
 
-  public <T> T runIfHasCapacity(java.util.function.Supplier<T> action) {
-    synchronized (this) {
+  /**
+   * Runs {@code action} (typically "persist a new report, then submit it") only if both the
+   * global and per-user queues currently have capacity for {@code user}. This is a best-effort
+   * pre-check performed before the caller does any persistence: if capacity looks exceeded, the
+   * corresponding unchecked {@link RequestQueueExceededException} or
+   * {@link UserQueueExceededException} is thrown and {@code action} never runs, so callers can
+   * rely on "throws → nothing persisted" (e.g. {@code ReportService#saveAndSubmitNew}).
+   * <p>
+   * This check is intentionally separate from the real reservation made later by
+   * {@link #admit(String, JsonNode, String, Runnable)} (which needs the id assigned during
+   * persistence), so a small race is possible between the two; {@code admit()} enforces the
+   * limits again at that point as the source of truth.
+   */
+  public <T> T runIfHasCapacity(String user, java.util.function.Supplier<T> action) {
+    var effectiveUser = resolveEffectiveUser(user);
+    synchronized (lockFor(effectiveUser)) {
       if (active.size() >= maxActive && pending.size() >= maxSize) {
         throw new RequestQueueExceededException(maxSize);
       }
+      var userActiveCount = activeByUser.getOrDefault(effectiveUser, Collections.emptySet()).size();
+      var userPendingCount = pendingByUser.getOrDefault(effectiveUser, Collections.emptySet()).size();
+      if (userActiveCount + userPendingCount >= maxActivePerUser) {
+        LOGGER.debugf("User %s exceeded per-user concurrent request limit of %d", effectiveUser, maxActivePerUser);
+        throw new UserQueueExceededException(maxActivePerUser);
+      }
     }
     return action.get();
+  }
+
+  private String resolveEffectiveUser(String user) {
+    return Objects.nonNull(user) && !user.isBlank() ? user : DEFAULT_USER;
   }
 
   private void trackActive(String id, String user) {

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
@@ -15,7 +15,9 @@
 package com.redhat.ecosystemappeng.exploitiq.service;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -56,8 +58,13 @@ public class RequestQueueService {
 
   private static final Logger LOGGER = Logger.getLogger(RequestQueueService.class);
 
+  private static final String DEFAULT_USER = "anonymous";
+
   @ConfigProperty(name = "exploit-iq.queue.max-active", defaultValue = "5")
   Integer maxActive;
+
+  @ConfigProperty(name = "exploit-iq.queue.max-active-per-user", defaultValue = "5")
+  Integer maxActivePerUser;
 
   @ConfigProperty(name = "exploit-iq.queue.max-size", defaultValue = "500")
   Integer maxSize;
@@ -77,13 +84,24 @@ public class RequestQueueService {
   @Inject
   Tracer tracer;
 
-  private Queue<String> pending = new ConcurrentLinkedQueue<>();
+  private record PendingRequest(String id, String user) {}
+
+  private Queue<PendingRequest> pending = new ConcurrentLinkedQueue<>();
   private Map<String, LocalDateTime> active = new ConcurrentHashMap<>();
+  private Map<String, String> activeUserById = new ConcurrentHashMap<>();
+  private Map<String, Set<String>> activeByUser = new ConcurrentHashMap<>();
+  private Map<String, Set<String>> pendingByUser = new ConcurrentHashMap<>();
+  // Lock striping: each user gets its own lock so that admission/promotion for one user never
+  // blocks another. Entries are intentionally never removed (safe lock-striping doesn't allow
+  // pruning while another thread might still hold/await the same lock); the map is bounded by
+  // the number of distinct users ever seen, which is acceptable at this scale.
+  private final Map<String, Object> userLocks = new ConcurrentHashMap<>();
   private LocalDateTime lastCheck = LocalDateTime.now();
 
   @Inject
   public RequestQueueService(MeterRegistry meterRegistry) {
     Gauge.builder("exploit-iq.request.queue.config.max-active", () -> maxActive).register(meterRegistry);
+    Gauge.builder("exploit-iq.request.queue.config.max-active-per-user", () -> maxActivePerUser).register(meterRegistry);
     Gauge.builder("exploit-iq.request.queue.config.max-size", () -> maxSize).register(meterRegistry);
     meterRegistry.gaugeCollectionSize("exploit-iq.request.queue.pending", Tags.empty(), pending);
     meterRegistry.gaugeMapSize("exploit-iq.request.queue.active", Tags.empty(), active);
@@ -91,7 +109,7 @@ public class RequestQueueService {
 
   @Scheduled(every = "10s")
   void checkQueue() {
-    var expired = new HashSet<>();
+    var expired = new HashSet<String>();
     active.entrySet().forEach(e -> {
       if (lastCheck.isAfter(e.getValue().plus(timeout))) {
         expired.add(e.getKey());
@@ -100,73 +118,142 @@ public class RequestQueueService {
             String.format("timeout after %s seconds", timeout.toSeconds()));
       }
     });
-    expired.forEach(active::remove);
+    expired.forEach(this::removeActive);
     lastCheck = LocalDateTime.now();
     moveToActive();
   }
 
   @PostConstruct
   void loadExistingQueue() {
-    repository.list(Map.of("status", "queued"), Collections.emptyList(), new Pagination(0, maxSize)).results.map(Report::id).forEach(pending::add);;
+    // Restore pending and in-flight ("sent") reports, otherwise a restart resets per-user/global
+    // counters and lets users bypass their concurrent-request limit. No locking is needed here:
+    // @PostConstruct runs before the app accepts traffic, so there's no concurrent admission to
+    // race against yet.
+    repository.list(Map.of("status", "queued"), Collections.emptyList(), new Pagination(0, maxSize)).results
+        .forEach(r -> trackPending(r.id(), resolveUser(r)));
+    repository.list(Map.of("status", "sent"), Collections.emptyList(), new Pagination(0, maxSize)).results
+        .forEach(r -> trackActive(r.id(), resolveUser(r), resolveSentAt(r)));
     LOGGER.debugf("Loaded %d elements from existing pending queue", pending.size());
+    LOGGER.debugf("Loaded %d elements from existing active queue", active.size());
+  }
+
+  private Object lockFor(String user) {
+    return userLocks.computeIfAbsent(user, k -> new Object());
+  }
+
+  private String resolveUser(Report report) {
+    if (Objects.nonNull(report.metadata())) {
+      var user = report.metadata().get("user");
+      if (Objects.nonNull(user)) {
+        return user;
+      }
+    }
+    return DEFAULT_USER;
+  }
+
+  private LocalDateTime resolveSentAt(Report report) {
+    if (Objects.nonNull(report.metadata())) {
+      var sentAt = report.metadata().get("sent_at");
+      if (Objects.nonNull(sentAt)) {
+        try {
+          return LocalDateTime.ofInstant(Instant.parse(sentAt), ZoneId.systemDefault());
+        } catch (Exception e) {
+          LOGGER.debugf("Unable to parse sent_at '%s' for report %s, defaulting to now()", sentAt, report.id());
+        }
+      }
+    }
+    return LocalDateTime.now();
   }
 
   private void moveToActive() {
-    String nextId;
-    while ((nextId = pollPendingIfCapacity()) != null) {
-      submitOneReportFromQueue(nextId);
+    PendingRequest next;
+    while ((next = pollPendingIfCapacity()) != null) {
+      submitOneReportFromQueue(next);
     }
   }
 
-  private synchronized String pollPendingIfCapacity() {
+  // Synchronized (rather than relying only on the per-user lock) so that a burst of concurrent
+  // scheduled passes can't all observe stale capacity and over-poll from the pending queue.
+  private synchronized PendingRequest pollPendingIfCapacity() {
     if (pending.isEmpty() || active.size() >= maxActive) {
       return null;
     }
     return pending.poll();
   }
 
-  private void submitOneReportFromQueue(String nextId) {
+  private void submitOneReportFromQueue(PendingRequest next) {
     Span span = tracer.spanBuilder("internal queue processing submit one former pending")
             .setSpanKind(SpanKind.INTERNAL)
             .startSpan();
-    var report = repository.findById(nextId);
-    LOGGER.debugf("Polled %s from the pending queue", nextId);
-    if (report != null) {
+    var report = repository.findById(next.id());
+    LOGGER.debugf("Polled %s from the pending queue", next.id());
+    if (Objects.nonNull(report)) {
       try {
         JsonNode jsonReport = objectMapper.readTree(report);
         MDC.put(TRACE_ID, jsonReport.get("input").get("scan").get("id").textValue());
         MDC.put(SPAN_ID, span.getSpanContext().getSpanId());
-        LOGGER.debugf("Submit report %s", nextId);
-        admit(nextId, jsonReport, () -> {});
+        LOGGER.debugf("Submit report %s", next.id());
+        // Drop the pending bookkeeping first so admit() re-evaluates this user's
+        // active+pending count without double-counting the request being promoted.
+        untrackPending(next);
+        admit(next.id(), jsonReport, next.user(), () -> {});
       } catch (JsonProcessingException e) {
         LOGGER.error("Unable to submit request", e);
-        repository.updateWithError(nextId, "json-processing-error", e.getMessage());
+        repository.updateWithError(next.id(), "json-processing-error", e.getMessage());
       }
     }
     span.end();
   }
 
-  public void admit(String id, JsonNode json, Runnable onAdmitted) {
+  /**
+   * Admits a report into the queue (active or pending) and, only once admission succeeds,
+   * runs {@code onAdmitted} (typically a repository status write). This keeps the queue
+   * reservation and the corresponding DB write atomic: if capacity is exceeded, an unchecked
+   * {@link RequestQueueExceededException} or {@link UserQueueExceededException} is thrown
+   * and {@code onAdmitted} never runs.
+   */
+  public void admit(String id, JsonNode json, String user, Runnable onAdmitted) {
+    var effectiveUser = Objects.nonNull(user) && !user.isBlank() ? user : DEFAULT_USER;
     boolean sendNow;
-    synchronized (this) {
+    // The compound check-then-act below only touches this user's own state (activeByUser/
+    // pendingByUser), so a per-user lock is sufficient - concurrent admission for other users
+    // proceeds without contention. active.size()/pending.size() are read without a lock since
+    // they're global counters where a small race-induced overshoot is harmless.
+    synchronized (lockFor(effectiveUser)) {
+      var userActiveCount = activeByUser.getOrDefault(effectiveUser, Collections.emptySet()).size();
+      var userPendingCount = pendingByUser.getOrDefault(effectiveUser, Collections.emptySet()).size();
+      // Cap active + pending combined, not just active: this guarantees that a user can never
+      // accumulate more than maxActivePerUser requests in flight in total, so promoting
+      // pending requests to active (see submitOneReportFromQueue()) can never push a user's
+      // active count past their limit either.
+      if (userActiveCount + userPendingCount >= maxActivePerUser) {
+        LOGGER.debugf("User %s exceeded per-user concurrent request limit of %d", effectiveUser, maxActivePerUser);
+        throw new UserQueueExceededException(maxActivePerUser);
+      }
       if (active.size() >= maxActive) {
         if (pending.size() >= maxSize) {
           throw new RequestQueueExceededException(maxSize);
         }
-        pending.add(id);
+        // Reserve the per-user slot in the same critical section as the check.
+        trackPending(id, effectiveUser);
         sendNow = false;
       } else {
-        active.put(id, LocalDateTime.now());
+        // Reserve the per-user slot in the same critical section as the check.
+        trackActive(id, effectiveUser);
         sendNow = true;
       }
     }
     onAdmitted.run();
     if (sendNow) {
       LOGGER.debugf("Submit report %s", id);
-      sendToExploitIq(id, json);
+      sendAsync(id, json);
     } else {
       LOGGER.debugf("Added %s to pending queue", id);
     }
+  }
+
+  public void queue(String id, JsonNode json, String user) {
+    admit(id, json, user, () -> {});
   }
 
   public <T> T runIfHasCapacity(java.util.function.Supplier<T> action) {
@@ -178,26 +265,69 @@ public class RequestQueueService {
     return action.get();
   }
 
-  private void sendToExploitIq(String id, JsonNode report) {
+  private void trackActive(String id, String user) {
+    trackActive(id, user, LocalDateTime.now());
+  }
+
+  private void trackActive(String id, String user, LocalDateTime sentAt) {
+    active.put(id, sentAt);
+    activeUserById.put(id, user);
+    activeByUser.computeIfAbsent(user, k -> ConcurrentHashMap.newKeySet()).add(id);
+  }
+
+  private void trackPending(String id, String user) {
+    pending.add(new PendingRequest(id, user));
+    pendingByUser.computeIfAbsent(user, k -> ConcurrentHashMap.newKeySet()).add(id);
+  }
+
+  private void untrackPending(PendingRequest request) {
+    var ids = pendingByUser.get(request.user());
+    if (Objects.nonNull(ids)) {
+      ids.remove(request.id());
+      if (ids.isEmpty()) {
+        pendingByUser.remove(request.user(), ids);
+      }
+    }
+  }
+
+  private void sendAsync(String id, JsonNode report) {
     try {
       exploitIqService.submitAsync(report.get("input").toPrettyString());
       repository.setAsSent(id);
       LOGGER.debugf("Report %s sent to ExploitIQ", id);
     } catch (Exception e) {
       LOGGER.error("Unable to submit request", e);
-      active.remove(id);
+      removeActive(id);
       repository.updateWithError(id, "exploit-iq-request-error", e.getMessage());
+    }
+  }
+
+  private void removeActive(String id) {
+    active.remove(id);
+    // activeUserById.remove(id) atomically resolves and clears the owning user; only the
+    // per-user activeByUser cleanup below needs to be synchronized on that user's lock.
+    var user = activeUserById.remove(id);
+    if (Objects.nonNull(user)) {
+      synchronized (lockFor(user)) {
+        var ids = activeByUser.get(user);
+        if (Objects.nonNull(ids)) {
+          ids.remove(id);
+          if (ids.isEmpty()) {
+            activeByUser.remove(user, ids);
+          }
+        }
+      }
     }
   }
 
   public void received(String id) {
     LOGGER.debugf("Received report %s. Removing from active queue.", id);
-    active.remove(id);
+    removeActive(id);
   }
 
   public void deleted(String id) {
     LOGGER.debugf("Removed deleted report %s. Removing from active queue.", id);
-    active.remove(id);
+    removeActive(id);
   }
 
   public void deleted(Collection<String> ids) {

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
@@ -193,10 +193,16 @@ public class RequestQueueService {
         MDC.put(TRACE_ID, jsonReport.get("input").get("scan").get("id").textValue());
         MDC.put(SPAN_ID, span.getSpanContext().getSpanId());
         LOGGER.debugf("Submit report %s", next.id());
-        // Drop the pending bookkeeping first so admit() re-evaluates this user's
-        // active+pending count without double-counting the request being promoted.
-        untrackPending(next);
-        admit(next.id(), jsonReport, next.user(), () -> {});
+        // untrackPending and trackActive must happen atomically under the same per-user lock:
+        // otherwise a concurrent admit() call for this user could observe the pending count
+        // already decremented but the active count not yet incremented, and admit one request
+        // too many. No need to re-check maxActivePerUser here: moving a request from pending to
+        // active doesn't change this user's active+pending total, only which bucket it's in.
+        synchronized (lockFor(next.user())) {
+          untrackPending(next);
+          trackActive(next.id(), next.user());
+        }
+        sendAsync(next.id(), jsonReport);
       } catch (JsonProcessingException e) {
         LOGGER.error("Unable to submit request", e);
         repository.updateWithError(next.id(), "json-processing-error", e.getMessage());

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
@@ -249,7 +249,20 @@ public class RequestQueueService {
         sendNow = true;
       }
     }
-    onAdmitted.run();
+    try {
+      onAdmitted.run();
+    } catch (Exception e) {
+      // Release the slot reserved above so a failing onAdmitted callback (e.g. a failed DB
+      // write) doesn't permanently consume queue capacity.
+      if (sendNow) {
+        removeActive(id);
+      } else {
+        var request = new PendingRequest(id, effectiveUser);
+        pending.remove(request);
+        untrackPending(request);
+      }
+      throw e;
+    }
     if (sendNow) {
       LOGGER.debugf("Submit report %s", id);
       sendAsync(id, json);

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/UserQueueExceededException.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/UserQueueExceededException.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.service;
+
+public class UserQueueExceededException extends RuntimeException {
+
+  public UserQueueExceededException(Integer maxActivePerUser) {
+    super("Exceeded per-user concurrent request limit: " + maxActivePerUser);
+  }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,7 +41,7 @@ quarkus.mongodb.devservices.image-name=docker.io/mongodb/mongodb-community-serve
 %prod.quarkus.mongodb.credentials.password=${MONGODB_PASSWORD}
 
 quarkus.native.resources.includes=includes.json,excludes.json,preProcessingTemplate.json
-quarkus.http.limits.max-body-size=300M
+quarkus.http.limits.max-body-size=90M
 quarkus.rest-client.exploit-iq.read-timeout=300000
 quarkus.http.limits.max-form-attribute-size=10K
 
@@ -188,6 +188,7 @@ exploit-iq.sse.heartbeat-interval=25S
 
 # Queue settings
 exploit-iq.queue.max-active=20
+exploit-iq.queue.max-active-per-user=5
 exploit-iq.queue.timeout=2h
 
 # Credential TTL automatically uses exploit-iq.queue.timeout (see CredentialStoreService)

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceQueueAdmissionTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceQueueAdmissionTest.java
@@ -100,7 +100,7 @@ class ReportServiceQueueAdmissionTest {
     ReportData unsaved = new ReportData(new ReportRequestId(null, "scan-x"), report);
 
     doThrow(new RequestQueueExceededException(2))
-        .when(queueService).runIfHasCapacity(any());
+        .when(queueService).runIfHasCapacity(any(), any());
 
     assertThrows(RequestQueueExceededException.class, () -> reportService.saveAndSubmitNew(unsaved));
 

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceQueueAdmissionTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceQueueAdmissionTest.java
@@ -69,15 +69,15 @@ class ReportServiceQueueAdmissionTest {
     when(userService.getUserName()).thenReturn("alice");
 
     doAnswer(invocation -> {
-      Runnable onAdmitted = invocation.getArgument(2);
+      Runnable onAdmitted = invocation.getArgument(3);
       onAdmitted.run();
       return null;
-    }).when(queueService).admit(eq("id-1"), eq(report), any(Runnable.class));
+    }).when(queueService).admit(eq("id-1"), eq(report), eq("alice"), any(Runnable.class));
 
     reportService.submit("id-1", report);
 
     verify(repository).setAsSubmitted("id-1", "alice");
-    verify(queueService).admit(eq("id-1"), eq(report), any(Runnable.class));
+    verify(queueService).admit(eq("id-1"), eq(report), eq("alice"), any(Runnable.class));
   }
 
   @Test
@@ -86,7 +86,7 @@ class ReportServiceQueueAdmissionTest {
     report.set("metadata", new ObjectMapper().createObjectNode());
     when(userService.getUserName()).thenReturn("alice");
     doThrow(new RequestQueueExceededException(2))
-        .when(queueService).admit(eq("id-2"), eq(report), any(Runnable.class));
+        .when(queueService).admit(eq("id-2"), eq(report), eq("alice"), any(Runnable.class));
 
     assertThrows(RequestQueueExceededException.class, () -> reportService.submit("id-2", report));
 
@@ -105,7 +105,7 @@ class ReportServiceQueueAdmissionTest {
     assertThrows(RequestQueueExceededException.class, () -> reportService.saveAndSubmitNew(unsaved));
 
     verify(repository, never()).save(any());
-    verify(queueService, never()).admit(any(), any(), any());
+    verify(queueService, never()).admit(any(), any(), any(), any());
   }
 
   @Test
@@ -118,10 +118,10 @@ class ReportServiceQueueAdmissionTest {
     when(objectMapper.readTree(reportJson)).thenReturn(parsedReport);
     when(userService.getUserName()).thenReturn("alice");
     doAnswer(invocation -> {
-      Runnable onAdmitted = invocation.getArgument(2);
+      Runnable onAdmitted = invocation.getArgument(3);
       onAdmitted.run();
       return null;
-    }).when(queueService).admit(eq("id-3"), any(), any(Runnable.class));
+    }).when(queueService).admit(eq("id-3"), any(), eq("alice"), any(Runnable.class));
 
     boolean retried = reportService.retry("id-3");
 
@@ -138,7 +138,7 @@ class ReportServiceQueueAdmissionTest {
     when(repository.findById("id-4")).thenReturn(reportJson);
     when(objectMapper.readTree(reportJson)).thenReturn(parsedReport);
     doThrow(new RequestQueueExceededException(2))
-        .when(queueService).admit(eq("id-4"), any(), any(Runnable.class));
+        .when(queueService).admit(eq("id-4"), any(), any(), any(Runnable.class));
 
     assertThrows(RequestQueueExceededException.class, () -> reportService.retry("id-4"));
     verify(repository, never()).setAsRetried(eq("id-4"), any());
@@ -151,6 +151,6 @@ class ReportServiceQueueAdmissionTest {
     boolean retried = reportService.retry("missing-id");
 
     assertFalse(retried);
-    verify(queueService, never()).admit(any(), any(), any(Runnable.class));
+    verify(queueService, never()).admit(any(), any(), any(), any(Runnable.class));
   }
 }

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueServiceTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueServiceTest.java
@@ -1,0 +1,228 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.ecosystemappeng.exploitiq.client.ExploitIqService;
+import com.redhat.ecosystemappeng.exploitiq.model.Pagination;
+import com.redhat.ecosystemappeng.exploitiq.model.PaginatedResult;
+import com.redhat.ecosystemappeng.exploitiq.repository.ReportRepositoryService;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerProvider;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.test.component.TestConfigProperty;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@QuarkusComponentTest
+@TestConfigProperty(key = "exploit-iq.queue.max-active", value = "10")
+@TestConfigProperty(key = "exploit-iq.queue.max-active-per-user", value = "2")
+@TestConfigProperty(key = "exploit-iq.queue.max-size", value = "100")
+@TestConfigProperty(key = "exploit-iq.queue.timeout", value = "5m")
+class RequestQueueServiceTest {
+
+  private static final int MAX_ACTIVE = 10;
+  private static final int MAX_ACTIVE_PER_USER = 2;
+
+  @Inject
+  RequestQueueService service;
+
+  @InjectMock
+  @RestClient
+  ExploitIqService exploitIqService;
+
+  @InjectMock
+  ReportRepositoryService repository;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  /**
+   * Real, dependency-free CDI beans that {@link RequestQueueService} needs but that we don't
+   * want to mock. {@code @QuarkusComponentTest} auto-mocks any otherwise-unsatisfied dependency,
+   * so these producers opt {@link ObjectMapper}, {@link Tracer} and {@link MeterRegistry} out of
+   * that and wire in working instances instead.
+   */
+  static class TestSupportBeans {
+
+    @Produces
+    @Singleton
+    ObjectMapper objectMapper() {
+      return new ObjectMapper();
+    }
+
+    @Produces
+    @Singleton
+    Tracer tracer() {
+      return TracerProvider.noop().get("test");
+    }
+
+    @Produces
+    @Singleton
+    MeterRegistry meterRegistry() {
+      return new SimpleMeterRegistry();
+    }
+  }
+
+  @BeforeEach
+  void setUp() throws Exception {
+    when(exploitIqService.submitAsync(anyString())).thenReturn(CompletableFuture.completedFuture(null));
+    // RequestQueueService restores queued/sent reports from the repository on startup
+    // (@PostConstruct); report an empty backlog so tests start from a clean queue.
+    when(repository.list(anyMap(), anyList(), any(Pagination.class)))
+        .thenAnswer(invocation -> new PaginatedResult<>(0, 0, Stream.empty()));
+  }
+
+  @Test
+  void queue_rejectsWhenUserHitsPerUserActiveLimit() throws Exception {
+    JsonNode report = sampleReport();
+
+    assertDoesNotThrow(() -> service.queue("r1", report, "alice"));
+    assertDoesNotThrow(() -> service.queue("r2", report, "alice"));
+
+    UserQueueExceededException ex = assertThrows(
+        UserQueueExceededException.class,
+        () -> service.queue("r3", report, "alice"));
+    assertTrue(ex.getMessage().contains(String.valueOf(MAX_ACTIVE_PER_USER)));
+  }
+
+  @Test
+  void queue_allowsOtherUsersWhenOneUserIsAtLimit() throws Exception {
+    JsonNode report = sampleReport();
+
+    service.queue("r1", report, "alice");
+    service.queue("r2", report, "alice");
+
+    assertThrows(UserQueueExceededException.class, () -> service.queue("r3", report, "alice"));
+    assertDoesNotThrow(() -> service.queue("r4", report, "bob"));
+  }
+
+  @Test
+  void queue_allowsUserAgainAfterActiveRequestIsReceived() throws Exception {
+    JsonNode report = sampleReport();
+
+    service.queue("r1", report, "alice");
+    service.queue("r2", report, "alice");
+    assertThrows(UserQueueExceededException.class, () -> service.queue("r3", report, "alice"));
+
+    service.received("r1");
+
+    assertDoesNotThrow(() -> service.queue("r3", report, "alice"));
+  }
+
+  @Test
+  void queue_treatsNullAndBlankUserAsAnonymous() throws Exception {
+    JsonNode report = sampleReport();
+
+    service.queue("r1", report, null);
+    service.queue("r2", report, "  ");
+
+    UserQueueExceededException ex = assertThrows(
+        UserQueueExceededException.class,
+        () -> service.queue("r3", report, null));
+    assertEquals("Exceeded per-user concurrent request limit: " + MAX_ACTIVE_PER_USER, ex.getMessage());
+  }
+
+  @Test
+  void queue_countsPendingRequestsTowardPerUserLimit() throws Exception {
+    JsonNode report = sampleReport();
+
+    // Saturate the global active queue with other users, each within their own per-user limit.
+    int fillerUsers = MAX_ACTIVE / MAX_ACTIVE_PER_USER;
+    for (int u = 0; u < fillerUsers; u++) {
+      for (int i = 0; i < MAX_ACTIVE_PER_USER; i++) {
+        service.queue("filler-" + u + "-" + i, report, "filler-" + u);
+      }
+    }
+
+    // Alice's requests land in pending because the global queue is already full. Her active
+    // count stays at 0 throughout, but pending now also counts toward her per-user limit.
+    assertDoesNotThrow(() -> service.queue("alice-1", report, "alice"));
+    assertDoesNotThrow(() -> service.queue("alice-2", report, "alice"));
+
+    UserQueueExceededException ex = assertThrows(
+        UserQueueExceededException.class,
+        () -> service.queue("alice-3", report, "alice"));
+    assertTrue(ex.getMessage().contains(String.valueOf(MAX_ACTIVE_PER_USER)));
+  }
+
+  @Test
+  void moveToActive_neverExceedsPerUserLimitAfterPromotingFromPending() throws Exception {
+    JsonNode report = sampleReport();
+    when(repository.findById(anyString())).thenReturn(report.toString());
+
+    // Saturate the global active queue with other users, each within their own per-user limit.
+    int fillerUsers = MAX_ACTIVE / MAX_ACTIVE_PER_USER;
+    for (int u = 0; u < fillerUsers; u++) {
+      for (int i = 0; i < MAX_ACTIVE_PER_USER; i++) {
+        service.queue("filler-" + u + "-" + i, report, "filler-" + u);
+      }
+    }
+
+    // Alice can only ever queue up to her per-user limit, even though it all lands in pending.
+    service.queue("alice-1", report, "alice");
+    service.queue("alice-2", report, "alice");
+    assertThrows(UserQueueExceededException.class, () -> service.queue("alice-3", report, "alice"));
+
+    // Free up global active slots and let the scheduled pass promote Alice's pending requests.
+    service.received("filler-0-0");
+    service.received("filler-0-1");
+    service.checkQueue();
+
+    // Promotion is observed externally: exactly Alice's per-user limit worth of her reports
+    // must have been marked as sent, and she must still be unable to queue beyond that limit.
+    ArgumentCaptor<String> sentIds = ArgumentCaptor.forClass(String.class);
+    verify(repository, atLeastOnce()).setAsSent(sentIds.capture());
+    long aliceSentCount = sentIds.getAllValues().stream().filter(id -> id.startsWith("alice")).count();
+    assertEquals(MAX_ACTIVE_PER_USER, aliceSentCount);
+
+    assertThrows(UserQueueExceededException.class, () -> service.queue("alice-4", report, "alice"));
+  }
+
+  private JsonNode sampleReport() throws Exception {
+    return objectMapper.readTree("""
+        {
+          "input": {
+            "scan": { "id": "scan-1" }
+          }
+        }
+        """);
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -19,3 +19,11 @@
 %test.quarkus.rest-client.github.url=http://localhost:${quarkus.wiremock.devservices.port}
 # Default timeout for async SPDX processing wait in REST tests (test-only config, not part of exploit-iq namespace).
 %test.rest-test.spdx-timeout=10m
+# Auth is disabled in @QuarkusTest REST tests (see RoleMappingAugmentor), so every request resolves
+# to the same "anonymous" user, and the mocked ExploitIQ backend (WireMock) never calls back to mark
+# reports as received, so admitted requests stay "active" for the rest of the suite. Without a
+# generous override here, the per-user limit (default 5, see RequestQueueService) is shared and
+# exhausted across the whole test run, causing unrelated tests to spuriously fail with
+# UserQueueExceededException. The dedicated per-user throttling behavior is covered in isolation by
+# RequestQueueServiceTest via @TestConfigProperty, independent of this shared default.
+%test.exploit-iq.queue.max-active-per-user=1000


### PR DESCRIPTION
A single authenticated user could submit enough large SBOM analysis
requests to fill every slot in the global active-request queue,
starving all other users for up to the queue timeout (T-011).
RequestQueueService now tracks active requests per user identity in
addition to the existing global count, and rejects a user's new
submission with a UserQueueExceededException (mapped to HTTP 429)
once they hit a configurable per-user limit
(exploit-iq.queue.max-active-per-user, default 5). Pending requests
retain their owning user so the limit is still enforced when they are
promoted from the pending queue to active.
- RequestQueueService: add max-active-per-user config, per-user active
  tracking (activeByUser/activeUserById), and PendingRequest record to
  carry user identity through the pending queue
- ReportService: pass resolved user identity into queue() for both
  submit() and retry(), and surface UserQueueExceededException as a
  distinct report error state
- ReportEndpoint/ProductEndpoint: map UserQueueExceededException to
  HTTP 429 with a dedicated message
- ComponentProcessingService: distinguish per-user limit errors in
  component submission failure messages
- AppConfig/application.properties/docs: document the new
  max-active-per-user setting

In addition - max-body-size has been reduced from 300M to 90M
