### PR TITLE
feat: support AWS Cognito as an OIDC provider for external-idp

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Check this other documents for:
 
 * [Configuration](./docs/configuration.md)
 * [Development](./docs/development.md)
+* [Authentication](./docs/authentication.md) — OpenShift OAuth, Keycloak, AWS Cognito, and API/M2M tokens
 * [Connecting to MongoDB](./docs/connecting-to-mongodb.md) — configuring ExploitIQ to connect to an external or self-managed MongoDB instance
 * [SBOM Requirements](./docs/sbom-requirements.md) — SPDX 2.3 structure, OCI image labels, and example fixtures
 * [Tests](./src/test/README.md) — REST `@QuarkusTest` notes and CI test image for pipelines

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -14,7 +14,7 @@ limitations under the License.
 
 # Authentication
 
-This guide covers authentication configuration for ExploitIQ Client, including OpenShift OAuth, external identity providers, and development setups.
+This guide covers authentication configuration for ExploitIQ Client, including OpenShift OAuth, external identity providers (Keycloak, AWS Cognito, Google, and others), and development setups.
 
 ## Overview
 
@@ -23,8 +23,10 @@ ExploitIQ supports multiple authentication modes via Quarkus profiles:
 | Profile | Use Case | Identity Provider |
 |---------|----------|-------------------|
 | `prod` | OpenShift | OpenShift OAuth |
-| `external-idp` | External identity providers | Keycloak, Google, Azure AD, Okta |
-| `dev` | Local development | Keycloak DevServices |
+| `external-idp` | External identity providers | Keycloak, AWS Cognito, Google, Azure AD, Okta |
+| `dev` | Local development | Keycloak DevServices (OIDC off by default) |
+
+No Cognito-specific Quarkus profile is required. Point the existing `external-idp` profile at a Cognito User Pool (discovery, hybrid app type, and access-token role source already fit Cognito).
 
 ### Authentication Methods
 
@@ -33,13 +35,14 @@ All profiles support both browser and API authentication:
 | Method | Use Case | Flow |
 |--------|----------|------|
 | Browser | Web UI | Authorization Code Flow (redirects to IdP) |
-| API | CLI, scripts, services | Bearer JWT token in `Authorization` header |
+| API | CLI, scripts, services, agent | Bearer JWT token in `Authorization` header |
 
-**Token acquisition differs by profile:**
+**Token acquisition differs by profile / IdP:**
 
 - `prod` (OpenShift): Use `oc whoami -t` or ServiceAccount tokens
-- `external-idp` (Keycloak): Use OIDC token endpoint with password grant
-- `dev`: Same as `external-idp` (DevServices Keycloak)
+- `external-idp` (Keycloak): OIDC token endpoint with password or client_credentials grant
+- `external-idp` (AWS Cognito): Hosted UI / managed login for browsers; `client_credentials` with **Basic auth** for M2M (agent)
+- `dev`: OIDC disabled by default; optional Keycloak DevServices when enabled
 
 ## OpenShift OAuth (Production)
 
@@ -179,16 +182,143 @@ env:
       key: client-secret
 ```
 
+### AWS Cognito
+
+Use the `external-idp` profile with an AWS Cognito User Pool for browser login and (with extra config) agent M2M bearer tokens.
+
+Cognito differs from Keycloak in important ways:
+
+| Topic | Cognito behavior |
+|-------|------------------|
+| Human roles | JWT `cognito:groups` claim (group names must match ExploitIQ roles exactly) |
+| M2M tokens | `client_credentials` tokens have **no** `cognito:groups`; authorize via OAuth2 `scope` → role mapping |
+| Token endpoint | `https://{domain}.auth.{region}.amazoncognito.com/oauth2/token` |
+| Client credentials | Requires **HTTP Basic** auth (`client_id:client_secret`), not body-only client auth |
+| Browser scopes | `openid`, `profile`, `email` (custom Resource Server scopes are for M2M only) |
+
+Role extraction is implemented in `RoleMappingAugmentor` (additive alongside OpenShift `groups` and Keycloak `realm_access` / `resource_access`). Do **not** set `quarkus.oidc.roles.role-claim-path=cognito:groups` on the shared `external-idp` profile — that would break Keycloak on the same profile.
+
+#### Cognito prerequisites (AWS Console)
+
+1. **User Pool** in your region.
+2. **Groups** named exactly:
+   - `exploit-iq-admin`
+   - `exploit-iq-view`
+   - `exploit-iq-prodsec`
+   - optionally `exploitiq-api-access` (for human users that should act like the API service role)
+3. **App client** (confidential / client secret) for the web UI:
+   - Authorization code grant
+   - Callback / sign-out URLs: your app origin (include both with and without trailing slash if needed), e.g. `http://localhost:8080` and `http://localhost:8080/`
+   - OpenID scopes: `openid`, `email`, `profile`
+4. **Cognito domain** (Amazon Cognito domain prefix is enough; custom domain is optional).
+5. **Users** in the pool, assigned to the groups above; set a **permanent** password for local testing (Forgot password needs email/SES configured).
+6. For **agent M2M** (optional, separate from browser client if desired):
+   - Resource Server with a custom scope, e.g. identifier `exploitiq-resource-server`, scope `exploitiq-api-access`
+   - App client with **client_credentials** grant and that custom scope enabled
+
+#### Environment variables (exploit-iq-client)
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `QUARKUS_PROFILE` | Use `external-idp` (locally prefer `dev,external-idp` so `%dev` defaults still apply) | `external-idp` or `dev,external-idp` |
+| `QUARKUS_OIDC_AUTH_SERVER_URL` | Cognito **issuer** URL (User Pool), **not** the Hosted UI domain and **not** `.../.well-known/openid-configuration` | `https://cognito-idp.eu-north-1.amazonaws.com/eu-north-1_AbCdEf123` |
+| `QUARKUS_OIDC_CLIENT_ID` | App client ID | Cognito console → App clients |
+| `QUARKUS_OIDC_CREDENTIALS_SECRET` | App client secret | Cognito console → App clients |
+| `EXPLOITIQ_SECURITY_OIDC_SCOPE_ROLE_MAPPINGS` | Optional M2M mapping: comma-separated `scope=role` pairs | `exploitiq-resource-server/exploitiq-api-access=exploitiq-api-access` |
+| `NAMESPACE` | Required for service-account role string expansion | OpenShift namespace, or `local-dev` locally |
+| `CREDENTIAL_ENCRYPTION_KEY` | 32-byte key for credential store (unrelated to Cognito) | Deployment secret |
+
+Discover endpoints automatically via:
+
+`https://cognito-idp.{region}.amazonaws.com/{user-pool-id}/.well-known/openid-configuration`
+
+Quarkus appends `/.well-known/openid-configuration` itself — set `QUARKUS_OIDC_AUTH_SERVER_URL` to the issuer only.
+
+#### Deployment example
+
+```yaml
+env:
+- name: QUARKUS_PROFILE
+  value: "external-idp"
+- name: QUARKUS_OIDC_AUTH_SERVER_URL
+  value: "https://cognito-idp.eu-north-1.amazonaws.com/eu-north-1_AbCdEf123"
+- name: QUARKUS_OIDC_CLIENT_ID
+  valueFrom:
+    secretKeyRef:
+      name: cognito-oidc
+      key: client-id
+- name: QUARKUS_OIDC_CREDENTIALS_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: cognito-oidc
+      key: client-secret
+# Required for agent/M2M bearer tokens (client_credentials) — omit for browser-only
+- name: EXPLOITIQ_SECURITY_OIDC_SCOPE_ROLE_MAPPINGS
+  value: "exploitiq-resource-server/exploitiq-api-access=exploitiq-api-access"
+```
+
+#### Local development with Cognito
+
+```bash
+export NAMESPACE=local-dev
+export CREDENTIAL_ENCRYPTION_KEY='dev-test-key-must-be-32bytes-long!'
+export QUARKUS_PROFILE=dev,external-idp
+export QUARKUS_OIDC_AUTH_SERVER_URL='https://cognito-idp.{region}.amazonaws.com/{user-pool-id}'
+export QUARKUS_OIDC_CLIENT_ID='{cognito-app-client-id}'
+export QUARKUS_OIDC_CREDENTIALS_SECRET='{cognito-app-client-secret}'
+# Optional M2M:
+# export EXPLOITIQ_SECURITY_OIDC_SCOPE_ROLE_MAPPINGS='exploitiq-resource-server/exploitiq-api-access=exploitiq-api-access'
+
+./mvnw quarkus:dev \
+  -Dquarkus.rest-client.exploit-iq.url=http://localhost:26466/generate
+```
+
+Open `http://localhost:8080` — you should be redirected to Cognito managed login / Hosted UI.
+
+**Session cookies:** After login, Quarkus stores an **HttpOnly** session cookie (typically `q_session`) on the app origin (`localhost:8080`). You will not see the Cognito JWT in `document.cookie` or as a readable Cognito token cookie. Check DevTools → Application → Cookies → `http://localhost:8080`.
+
+#### Verify browser roles (`cognito:groups`)
+
+1. Confirm the user is a member of `exploit-iq-admin` (or `view` / `prodsec`) in Cognito.
+2. After login, APIs should return **200** (not **403**).
+3. Quarkus logs should include: `Mapping user to role 'exploit-iq-admin' from source: Cognito Group`.
+4. Optional: decode the **access** token (not only the ID token) and confirm a `cognito:groups` array with those exact names.
+
+#### Agent / M2M bearer tokens (client side)
+
+Cognito `client_credentials` access tokens do **not** include `cognito:groups`. The client authorizes them by mapping the token `scope` claim via `exploitiq.security.oidc.scope-role-mappings` (env: `EXPLOITIQ_SECURITY_OIDC_SCOPE_ROLE_MAPPINGS`) onto an allowed role such as `exploitiq-api-access` (already listed in `exploitiq.security.service-account-roles`).
+
+Fetch a token (agent-side code lives in the vulnerability-analysis repo; this shows the Cognito contract):
+
+```bash
+COGNITO_DOMAIN="{prefix}.auth.{region}.amazoncognito.com"   # from Cognito Domain, not cognito-idp issuer
+CLIENT_ID="{m2m-app-client-id}"
+CLIENT_SECRET="{m2m-app-client-secret}"
+SCOPE="exploitiq-resource-server/exploitiq-api-access"
+
+TOKEN=$(curl -s -X POST "https://${COGNITO_DOMAIN}/oauth2/token" \
+  -u "${CLIENT_ID}:${CLIENT_SECRET}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&scope=${SCOPE}" | jq -r .access_token)
+
+curl -i -H "Authorization: Bearer ${TOKEN}" \
+  http://localhost:8080/api/v1/reports
+```
+
+Expect **200** when scope mapping is configured on the client. Without `EXPLOITIQ_SECURITY_OIDC_SCOPE_ROLE_MAPPINGS`, the token may authenticate but fail authorization (**403**).
+
+**Note:** Implementing Cognito token fetch in the Python agent (`AUTH_TYPE=cognito`, `COGNITO_DOMAIN`, etc.) is outside this repository.
+
 ### Other OIDC Providers
 
-The same approach works with any OIDC-compliant provider:
+The same `external-idp` approach works with other OIDC-compliant providers:
 
 | Provider | Auth Server URL |
 |----------|-----------------|
 | Azure AD | `https://login.microsoftonline.com/{tenant}/v2.0` |
 | Okta | `https://dev-xxxxx.okta.com/oauth2/default` |
 | Auth0 | `https://your-domain.auth0.com` |
-| AWS Cognito | `https://cognito-idp.{region}.amazonaws.com/{userPoolId}` |
+| AWS Cognito | See [AWS Cognito](#aws-cognito) above |
 
 **Note:** GitHub does not support OIDC. Use Keycloak as an identity broker for GitHub authentication.
 
@@ -241,7 +371,7 @@ curl -H "Authorization: Bearer $USER_TOKEN" \
 
 ### Service-to-Service Authentication (Optional)
 
-For machine-to-machine communication, use the client credentials grant:
+For machine-to-machine communication with **Keycloak**, use the client credentials grant:
 
 ```bash
 # Get service token
@@ -256,6 +386,8 @@ curl -H "Authorization: Bearer $SERVICE_TOKEN" \
 ```
 
 **Note:** Requires a separate Keycloak client configured for service accounts.
+
+For **AWS Cognito** M2M (`client_credentials` + Basic auth + custom scope), see [AWS Cognito — Agent / M2M bearer tokens](#agent--m2m-bearer-tokens-client-side).
 
 ### Token Validation
 
@@ -375,38 +507,50 @@ curl -H "Authorization: Bearer $USER_TOKEN" \
 
 ## User Display
 
-The application displays user information with this priority:
+The application resolves a display / actor name with this priority (`UserService`):
 
 1. `email` claim (primary)
 2. `upn` claim (User Principal Name)
 3. `metadata.name` (OpenShift)
-4. `anonymous` (fallback)
+4. `preferred_username`
+5. `sub`
+6. `anonymous` (fallback)
 
-Ensure your identity provider or Keycloak is configured to include the `email` claim in tokens.
+For browser sessions, Quarkus may use UserInfo; for pure bearer M2M calls, the JWT principal name (`sub`, often the Cognito app client id) is typically used. Ensure your IdP includes `email` (or another claim above) for human users when you care about UI display names.
 
 ## Role Mapping
 
-The application implements a **Unified Role Mapping** strategy, allowing you to manage permissions using either OpenShift Groups or OIDC Roles (Keycloak), depending on your environment.
+The application implements a **unified role mapping** strategy in `RoleMappingAugmentor`. On every authenticated request it inspects the JWT (and, for OpenShift `prod`, UserInfo-backed claims) and grants only roles that appear in the configured allow-list (`quarkus.http.auth.policy.role-policy.roles-allowed`, which includes human roles plus `exploitiq.security.service-account-roles`).
 
-The application looks for specific **Target Roles** (configurable via `exploit-iq.security.target-roles`):
+**Target human roles:**
+
 - `exploit-iq-admin`: Admin access
 - `exploit-iq-view`: Read-only access
 - `exploit-iq-prodsec`: Product Security access
 
-### OpenShift Groups (Production)
-In the `prod` profile, OpenShift Groups are automatically mapped to these roles.
-- Group `exploit-iq-admin` -> Mapped to `exploit-iq-admin`
-- Group `exploit-iq-view` -> Mapped to `exploit-iq-view`
-- Group `exploit-iq-prodsec` -> Mapped to `exploit-iq-prodsec`
+**Service-account style roles** (skip report owner checks when held): configured via `exploitiq.security.service-account-roles`, including OpenShift SA names and `exploitiq-api-access`.
 
-### OIDC Roles (Keycloak / External)
-In `external-idp` or `dev` profiles, roles are extracted from the OIDC token:
-- **Realm Roles:** `exploit-iq-admin`, `exploit-iq-view`
-- **Resource Access (Client Roles):** Roles defined specifically for the `exploit-iq-client` client.
+### OpenShift Groups (`prod`)
 
-This flexibility allows you to choose the management style that fits your platform:
-- **OpenShift Native:** Access is controlled by OpenShift Groups.
-- **Identity Provider:** Access is controlled by Keycloak/IdP roles.
+OpenShift Groups from UserInfo / `groups` are mapped when the group name matches a target role:
+
+- Group `exploit-iq-admin` → `exploit-iq-admin`
+- Group `exploit-iq-view` → `exploit-iq-view`
+- Group `exploit-iq-prodsec` → `exploit-iq-prodsec`
+
+Kubernetes ServiceAccount JWTs may also map via the `kubernetes.io` claim / `sub` when configured in the allow-list.
+
+### OIDC Roles (Keycloak / `external-idp` / `dev`)
+
+- **Realm roles:** `realm_access.roles`
+- **Client roles:** `resource_access.{client-id}.roles` for `exploit-iq-client`
+
+### AWS Cognito (`external-idp`)
+
+- **Browser / user tokens:** `cognito:groups` — each group name that matches a target role is granted (e.g. Cognito group `exploit-iq-admin` → role `exploit-iq-admin`).
+- **M2M / `client_credentials` tokens:** no group claim; configure `exploitiq.security.oidc.scope-role-mappings` (env `EXPLOITIQ_SECURITY_OIDC_SCOPE_ROLE_MAPPINGS`) as `scope=role` pairs, e.g. `exploitiq-resource-server/exploitiq-api-access=exploitiq-api-access`.
+
+When Cognito env vars and scope mappings are unset, Cognito-specific paths are no-ops; OpenShift and Keycloak behavior is unchanged.
 
 ## Troubleshooting
 
@@ -434,6 +578,49 @@ This flexibility allows you to choose the management style that fits your platfo
 1. Ensure `scope=openid profile email` is included in token request
 2. Verify token is not expired
 3. Check Keycloak logs for "Missing openid scope" error
+
+### API Returns 403 Forbidden (authenticated but no role)
+
+**Cause:** Token validated but no matching ExploitIQ role was mapped.
+
+**Solution (Cognito browser):**
+
+1. Confirm the user is in a Cognito group named exactly `exploit-iq-admin`, `exploit-iq-view`, or `exploit-iq-prodsec`
+2. Confirm the **access** token contains `cognito:groups` with those names
+3. Check logs for `Mapping user to role ... from source: Cognito Group`
+
+**Solution (Cognito M2M):**
+
+1. Set `EXPLOITIQ_SECURITY_OIDC_SCOPE_ROLE_MAPPINGS` to map your custom scope to `exploitiq-api-access`
+2. Ensure the token `scope` claim contains that exact scope string
+3. Check logs for `Mapping user to role ... from source: Cognito M2M Scope`
+
+### Cognito: invalid_scope / Client is not enabled for OAuth2.0 flows
+
+**Cause:** App client Hosted UI / OAuth settings incomplete.
+
+**Solution:**
+
+1. Enable Authorization code grant
+2. Allow scopes `openid`, `email`, `profile` for browser clients
+3. Set callback URLs to the exact app origin (with and without trailing `/`)
+4. Ensure a Cognito domain exists and managed login status is Available
+
+### Cognito: OIDC Server is not available / BadRequest on discovery
+
+**Cause:** Wrong `QUARKUS_OIDC_AUTH_SERVER_URL`.
+
+**Solution:** Use the issuer only:
+
+`https://cognito-idp.{region}.amazonaws.com/{user-pool-id}`
+
+Do **not** append `/.well-known/openid-configuration` (Quarkus adds it). Do **not** use the `{prefix}.auth.{region}.amazoncognito.com` Hosted UI domain as `auth-server-url`.
+
+### Cognito: no cookies visible after login
+
+**Cause:** Looking in the wrong place, or expecting a readable JWT cookie.
+
+**Solution:** Quarkus sets an HttpOnly session cookie (often `q_session`) on the **application** origin. Check DevTools → Application → Cookies → `http://localhost:8080` (not the Cognito domain). `document.cookie` will not show HttpOnly cookies.
 
 ### HTTPS Required Error (Keycloak)
 
@@ -470,5 +657,7 @@ Or run the testing script with debug flag:
 - [Quarkus OIDC Bearer Token Authentication](https://quarkus.io/guides/security-oidc-bearer-token-authentication)
 - [Quarkus Configuring Well-Known OpenID Connect Providers](https://quarkus.io/guides/security-openid-connect-providers)
 - [Keycloak Documentation](https://www.keycloak.org/documentation)
+- [Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html)
+- [Amazon Cognito OAuth 2.0 / OIDC endpoints](https://docs.aws.amazon.com/cognito/latest/developerguide/federation-endpoints.html)
 - [GitHub OAuth Apps](https://docs.github.com/en/developers/apps/building-oauth-apps)
 - [Google OAuth 2.0](https://developers.google.com/identity/protocols/oauth2)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 ## Authentication
 
-For detailed authentication configuration including OpenShift OAuth, Keycloak, and external identity providers (Google, GitHub, Azure AD), see the [Authentication Guide](./authentication.md).
+For detailed authentication configuration including OpenShift OAuth, Keycloak, AWS Cognito, and other external identity providers (Google, Azure AD, Okta), see the [Authentication Guide](./authentication.md).
 
 ## External Services (GitHub / ExploitIQ)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 To see all the configuration options check the [configuration](./configuration.md) guide.
 
-For authentication setup (Keycloak, external identity providers, testing), see the [authentication](./authentication.md) guide.
+For authentication setup (Keycloak, AWS Cognito, other external IdPs, testing), see the [authentication](./authentication.md) guide.
 
 To connect the application to an external MongoDB instance, refer to [Connecting to MongoDB](./connecting-to-mongodb.md).
 
@@ -37,6 +37,8 @@ By default, this runs with **authentication disabled**. To enable Keycloak DevSe
 ```shell
 ./mvnw quarkus:dev -Dquarkus.oidc.enabled=true -Dquarkus.keycloak.devservices.enabled=true
 ```
+
+To use **AWS Cognito** locally, set `QUARKUS_PROFILE=dev,external-idp` and the Cognito OIDC env vars documented in [authentication.md — AWS Cognito](./authentication.md#aws-cognito).
 
 This runs both the backend and frontend together, with the UI served through Quarkus at `http://localhost:8080`.
 
@@ -153,7 +155,7 @@ You can then execute your native executable with: `./target/exploit-iq-client-1.
 Some Quarkus properties are **build-time only** and cannot be changed at runtime. When building for a specific deployment target, include the profile:
 
 ```shell
-# For external-idp deployments (Keycloak, Google, etc.)
+# For external-idp deployments (Keycloak, AWS Cognito, Google, etc.)
 ./mvnw package -Dnative -Dquarkus.profile=external-idp
 
 # For prod deployments (OpenShift OAuth) - default

--- a/openspec/specs/oidc-authentication/spec.md
+++ b/openspec/specs/oidc-authentication/spec.md
@@ -1,0 +1,64 @@
+# oidc-authentication Specification
+
+## Purpose
+Define how ExploitIQ maps OIDC identity-provider JWT claims to application roles across OpenShift OAuth, Keycloak, and AWS Cognito (browser login and M2M), including non-regression guarantees for existing IdP paths.
+## Requirements
+### Requirement: AWS Cognito browser login role mapping
+
+`RoleMappingAugmentor` SHALL extract application roles from the `cognito:groups` claim (a JSON array of group names) on the identity's JWT, in addition to the existing `groups` (OpenShift), `realm_access.roles`/`resource_access.{client-id}.roles` (Keycloak), and Kubernetes service-account (`kubernetes.io`) claim checks. For each value in `cognito:groups` that matches a configured target role (`quarkus.http.auth.policy.role-policy.roles-allowed`), the augmentor SHALL grant that role to the identity, without duplicating roles already granted by another claim path. This claim check SHALL run unconditionally alongside the existing checks on every authenticated request, requiring no new Quarkus profile: the `external-idp` profile's existing `discovery-enabled=true`, `roles.source=accesstoken`, and `application-type=hybrid` settings SHALL work unmodified against a Cognito User Pool's `.well-known/openid-configuration`.
+
+#### Scenario: Cognito group matching a target role is granted
+
+- **WHEN** an authenticated request carries a JWT with `cognito:groups` containing `exploit-iq-admin`
+- **AND** `exploit-iq-admin` is present in the configured target roles
+- **THEN** the augmented identity is granted the `exploit-iq-admin` role
+
+#### Scenario: Cognito group not matching any target role is ignored
+
+- **WHEN** an authenticated request carries a JWT with `cognito:groups` containing a group name that is not in the configured target roles
+- **THEN** the augmented identity is not granted a role for that group name
+- **AND** no error is raised
+
+#### Scenario: Missing cognito:groups claim does not affect other providers
+
+- **WHEN** an authenticated request carries a JWT without a `cognito:groups` claim
+- **THEN** the augmentor skips Cognito group role mapping
+- **AND** continues to evaluate `groups`, `realm_access`/`resource_access`, and `kubernetes.io` claim paths unaffected
+
+### Requirement: AWS Cognito M2M scope-to-role mapping
+
+`RoleMappingAugmentor` SHALL support authorizing AWS Cognito `client_credentials` (M2M) bearer tokens, which carry no group claim, by mapping the token's OAuth2 `scope` claim (a space-delimited string) to application roles using a configurable `exploitiq.security.oidc.scope-role-mappings` property (a map of scope value to role name, empty by default). For each configured mapping whose scope value is present in the token's `scope` claim, the augmentor SHALL grant the mapped role, provided that role is also present in the configured target roles. This mechanism SHALL be provider-agnostic (keyed only on the standard `scope` claim), opt-in via configuration, and SHALL NOT alter role resolution for tokens where `exploitiq.security.oidc.scope-role-mappings` is unset or the `scope` claim is absent.
+
+#### Scenario: M2M token scope matching a configured mapping is granted the mapped role
+
+- **WHEN** an authenticated request carries a JWT with a `scope` claim containing `exploitiq-resource-server/exploitiq-api-access`
+- **AND** `exploitiq.security.oidc.scope-role-mappings` maps `exploitiq-resource-server/exploitiq-api-access` to `exploitiq-api-access`
+- **AND** `exploitiq-api-access` is present in the configured target roles
+- **THEN** the augmented identity is granted the `exploitiq-api-access` role
+
+#### Scenario: M2M token without a matching configured scope mapping is not granted a role
+
+- **WHEN** an authenticated request carries a JWT with a `scope` claim that does not match any configured `exploitiq.security.oidc.scope-role-mappings` entry
+- **THEN** no role is granted via scope-based mapping
+- **AND** the request is still evaluated against roles granted by other claim paths
+
+#### Scenario: Cognito M2M token is authorized to call the API
+
+- **WHEN** the `exploit-iq-agent` service calls the `exploit-iq-client` API with a bearer token obtained from Cognito's token endpoint via `client_credentials` grant, whose `scope` claim matches a configured `exploitiq-api-access` mapping
+- **THEN** the request is authorized by the global `role-policy` (which allows `exploitiq-api-access`)
+- **AND** the caller identity resolves to the JWT `sub` claim (the Cognito App Client ID) for actor attribution, since no `UserInfo` is available for M2M requests
+
+### Requirement: Existing OpenShift and Keycloak role mapping unaffected
+
+Adding AWS Cognito claim support SHALL NOT change role resolution behavior for OpenShift OAuth (`prod` profile, `groups`/`userinfo` roles source) or Keycloak (`external-idp`/`dev` profiles, `realm_access`/`resource_access` roles source) identities. The new `cognito:groups` and `scope`-based checks SHALL be no-ops when their respective claims or configuration are absent.
+
+#### Scenario: OpenShift identity unaffected by Cognito support
+
+- **WHEN** an authenticated request carries an OpenShift JWT/UserInfo with a `groups` claim and no `cognito:groups` or matching `scope` mapping
+- **THEN** roles are granted exactly as before this change, via the `groups` claim path only
+
+#### Scenario: Keycloak identity unaffected by Cognito support
+
+- **WHEN** an authenticated request carries a Keycloak JWT with `realm_access.roles` and/or `resource_access.{client-id}.roles` and no `cognito:groups` claim
+- **THEN** roles are granted exactly as before this change, via the Keycloak claim paths only
+

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentor.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentor.java
@@ -21,6 +21,7 @@ import io.quarkus.security.identity.SecurityIdentityAugmentor;
 import io.quarkus.security.runtime.QuarkusPrincipal;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.smallrye.mutiny.Uni;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import jakarta.json.JsonArray;
@@ -31,18 +32,25 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jboss.logging.Logger;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 /**
  * Security Augmentor to map external Identity Provider roles to internal
  * application roles.
  *
- * Different Identity Providers (OpenShift, Keycloak) store role information in
- * different JWT claims:
+ * Different Identity Providers (OpenShift, Keycloak, AWS Cognito) store role
+ * information in different JWT claims:
  * - OpenShift: 'groups'
  * - Keycloak: 'realm_access.roles' or 'resource_access.{client_id}.roles'
+ * - AWS Cognito (browser login): 'cognito:groups'
+ * - AWS Cognito (M2M client_credentials): no group claim; roles are derived
+ *   from the standard OAuth2 'scope' claim via the configurable
+ *   {@code exploitiq.security.oidc.scope-role-mappings} property.
  *
  * This augmentor unifies role extraction logic to ensure consistent
  * authorization regardless of the IDP.
@@ -69,7 +77,44 @@ public class RoleMappingAugmentor implements SecurityIdentityAugmentor {
     @ConfigProperty(name = "quarkus.oidc.enabled", defaultValue = "true")
     boolean oidcEnabled;
 
+    /**
+     * AWS Cognito M2M (client_credentials) role mapping, expressed as a set of
+     * "scope=role" pairs, e.g.
+     * {@code exploitiq-resource-server/exploitiq-api-access=exploitiq-api-access}.
+     * Unset/empty by default (an unconfigured/blank property yields an empty
+     * {@link Optional}, never a validation failure). Provider-agnostic: keyed
+     * only on the standard OAuth2 'scope' claim, so it has no effect for any IdP
+     * unless explicitly configured.
+     */
+    @ConfigProperty(name = "exploitiq.security.oidc.scope-role-mappings")
+    Optional<Set<String>> scopeRoleMappings;
+
+    private Map<String, String> parsedScopeRoleMappings = Map.of();
+
     private boolean loggedDevModeWarning = false;
+
+    @PostConstruct
+    void initScopeRoleMappings() {
+        if (scopeRoleMappings == null || scopeRoleMappings.isEmpty()) {
+            parsedScopeRoleMappings = Map.of();
+            return;
+        }
+        Map<String, String> mappings = new HashMap<>();
+        for (String pair : scopeRoleMappings.get()) {
+            if (pair == null || pair.isBlank()) {
+                continue;
+            }
+            int idx = pair.indexOf('=');
+            if (idx <= 0 || idx == pair.length() - 1) {
+                LOG.warnf(
+                        "Ignoring malformed exploitiq.security.oidc.scope-role-mappings entry: '%s'. Expected format 'scope=role'.",
+                        pair);
+                continue;
+            }
+            mappings.put(pair.substring(0, idx).trim(), pair.substring(idx + 1).trim());
+        }
+        parsedScopeRoleMappings = Map.copyOf(mappings);
+    }
 
     /**
      * Augments the security identity.
@@ -166,6 +211,24 @@ public class RoleMappingAugmentor implements SecurityIdentityAugmentor {
                     }
                 }
             }
+
+            // AWS Cognito (browser login): 'cognito:groups' claim (list of group names)
+            Object cognitoGroupsObj = jwt.getClaim("cognito:groups");
+            checkClaimAndMapRoles(cognitoGroupsObj, "Cognito Group", addedRoles, builder);
+
+            // AWS Cognito (M2M client_credentials): no group claim is present, so map the
+            // standard OAuth2 'scope' claim to roles via the configured scope-role mappings.
+            // No-op unless exploitiq.security.oidc.scope-role-mappings is configured.
+            Object scopeClaim = jwt.getClaim("scope");
+            if (scopeClaim instanceof String scopeStr && !scopeStr.isBlank() && !parsedScopeRoleMappings.isEmpty()) {
+                Set<String> tokenScopes = Set.of(scopeStr.trim().split("\\s+"));
+                for (Map.Entry<String, String> entry : parsedScopeRoleMappings.entrySet()) {
+                    if (tokenScopes.contains(entry.getKey())) {
+                        processRole(entry.getValue(), "Cognito M2M Scope", addedRoles, builder);
+                    }
+                }
+            }
+
             return builder.build();
         }
         return identity;

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentor.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentor.java
@@ -224,7 +224,14 @@ public class RoleMappingAugmentor implements SecurityIdentityAugmentor {
                 Set<String> tokenScopes = Set.of(scopeStr.trim().split("\\s+"));
                 for (Map.Entry<String, String> entry : parsedScopeRoleMappings.entrySet()) {
                     if (tokenScopes.contains(entry.getKey())) {
-                        processRole(entry.getValue(), "Cognito M2M Scope", addedRoles, builder);
+                        String mappedRole = entry.getValue();
+                        if (!targetRoles.contains(mappedRole)) {
+                            LOG.warnf(
+                                    "Ignoring scope-role mapping '%s=%s': role '%s' is not in the configured target roles %s",
+                                    entry.getKey(), mappedRole, mappedRole, targetRoles);
+                            continue;
+                        }
+                        processRole(mappedRole, "Cognito M2M Scope", addedRoles, builder);
                     }
                 }
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -59,11 +59,24 @@ quarkus.http.limits.max-form-attribute-size=10K
 #   Use cases:
 #     - OpenShift/Kubernetes with Keycloak (standalone or as Identity Broker)
 #     - Direct GitHub/Google OAuth (without Keycloak)
+#     - AWS Cognito (browser login + agent M2M)
 #   Activation: QUARKUS_PROFILE=external-idp
 #   Required environment variables:
 #     For Keycloak: QUARKUS_OIDC_AUTH_SERVER_URL, QUARKUS_OIDC_CREDENTIALS_SECRET
 #     For Direct Google/GitHub: QUARKUS_OIDC_PROVIDER=google|github,
 #       QUARKUS_OIDC_CLIENT_ID, QUARKUS_OIDC_CREDENTIALS_SECRET
+#     For AWS Cognito:
+#       QUARKUS_OIDC_AUTH_SERVER_URL=https://cognito-idp.{region}.amazonaws.com/{user-pool-id}
+#       QUARKUS_OIDC_CLIENT_ID={cognito-app-client-id}
+#       QUARKUS_OIDC_CREDENTIALS_SECRET={cognito-app-client-secret}
+#       Browser login roles: Cognito 'cognito:groups' claim is mapped automatically
+#         (see RoleMappingAugmentor); no extra config needed as long as group names
+#         match the configured application roles (exploit-iq-admin, etc.).
+#       Agent M2M authorization: Cognito client_credentials tokens have no group
+#         claim, so map the token's 'scope' claim to a role via (comma-separated
+#         "scope=role" pairs for multiple mappings):
+#         EXPLOITIQ_SECURITY_OIDC_SCOPE_ROLE_MAPPINGS=exploitiq-resource-server/exploitiq-api-access=exploitiq-api-access
+#         (see exploitiq.security.oidc.scope-role-mappings below)
 #
 # Profile: dev
 #   Use case: Local development with Keycloak DevServices
@@ -145,6 +158,10 @@ quarkus.http.auth.permission.management.policy=permit
 # Service-account roles (OIDC-provider agnostic): used for HTTP auth and to skip report owner verification.
 # Outside exploit-iq.* AppConfig mapping so native builds do not bake unresolved ${NAMESPACE}.
 exploitiq.security.service-account-roles=system:serviceaccount:${NAMESPACE}:exploit-iq-sa,system:serviceaccount:${NAMESPACE}:pipeline,exploitiq-api-access
+
+# AWS Cognito M2M (client_credentials) role mapping: comma-separated "scope=role" pairs.
+# Unset by default (no effect on OpenShift/Keycloak); set per-deployment for Cognito M2M, e.g.:
+#   exploitiq.security.oidc.scope-role-mappings=exploitiq-resource-server/exploitiq-api-access=exploitiq-api-access
 
 # Global policy: Require authentication and at least one role
 quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,${exploitiq.security.service-account-roles}

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentorScopeMappingsUnconfiguredTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentorScopeMappingsUnconfiguredTest.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.security;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.test.component.TestConfigProperty;
+
+/**
+ * Regression coverage for the real deployment/dev-mode default: when
+ * {@code exploitiq.security.oidc.scope-role-mappings} is entirely unset (as it
+ * is out of the box, unlike {@link RoleMappingAugmentorTest} which overrides
+ * it via {@code @TestConfigProperty}), the bean must still start up and
+ * augment identities normally rather than failing config validation.
+ *
+ * <p>This is a dedicated top-level test (rather than a case inside
+ * {@link RoleMappingAugmentorTest}) because {@code @QuarkusComponentTest}
+ * builds one component container per test class from that class's
+ * {@code @TestConfigProperty} overrides.
+ */
+@QuarkusComponentTest
+@TestConfigProperty(key = "exploitiq.security.service-account-roles", value = "system:serviceaccount:exploit-iq:exploit-iq-sa,exploitiq-api-access")
+class RoleMappingAugmentorScopeMappingsUnconfiguredTest {
+
+    @Inject
+    RoleMappingAugmentor augmentor;
+
+    @Test
+    void scopeClaimPresentButNoMappingsConfigured_doesNotFailStartupAndGrantsNoRole() {
+        JsonWebToken jwt = new RoleMappingAugmentorTest.FakeJsonWebToken(
+                Map.of("scope", "exploitiq-resource-server/exploitiq-api-access"));
+        SecurityIdentity identity = QuarkusSecurityIdentity.builder().setPrincipal(jwt).build();
+
+        SecurityIdentity result = augmentor.augment(identity, null).await().indefinitely();
+
+        assertTrue(result.getRoles().isEmpty());
+    }
+
+    @Test
+    void otherProviderPathsStillWorkWhenScopeMappingsUnconfigured() {
+        JsonWebToken jwt = new RoleMappingAugmentorTest.FakeJsonWebToken(Map.of("groups", List.of("exploit-iq-admin")));
+        SecurityIdentity identity = QuarkusSecurityIdentity.builder().setPrincipal(jwt).build();
+
+        SecurityIdentity result = augmentor.augment(identity, null).await().indefinitely();
+
+        assertTrue(result.getRoles().contains("exploit-iq-admin"));
+    }
+}

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentorScopeMapsToUnknownRoleTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentorScopeMapsToUnknownRoleTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.test.component.TestConfigProperty;
+
+/**
+ * Scope maps to a role that is not in {@code roles-allowed}: must not be granted
+ * (and the augmentor warns — see {@link RoleMappingAugmentor}).
+ */
+@QuarkusComponentTest
+@TestConfigProperty(key = "exploitiq.security.oidc.scope-role-mappings", value = "exploitiq-resource-server/exploitiq-api-access=not-a-configured-role")
+@TestConfigProperty(key = "exploitiq.security.service-account-roles", value = "system:serviceaccount:exploit-iq:exploit-iq-sa,exploitiq-api-access")
+class RoleMappingAugmentorScopeMapsToUnknownRoleTest {
+
+    @Inject
+    RoleMappingAugmentor augmentor;
+
+    @Test
+    void m2mScopeMappingToRoleOutsideTargetRoles_isNotGranted() {
+        JsonWebToken jwt = new RoleMappingAugmentorTest.FakeJsonWebToken(
+                Map.of("scope", "exploitiq-resource-server/exploitiq-api-access"));
+        SecurityIdentity identity = QuarkusSecurityIdentity.builder().setPrincipal(jwt).build();
+
+        SecurityIdentity result = augmentor.augment(identity, null).await().indefinitely();
+
+        assertFalse(result.getRoles().contains("not-a-configured-role"));
+        assertTrue(result.getRoles().isEmpty());
+    }
+}

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentorTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/security/RoleMappingAugmentorTest.java
@@ -1,0 +1,147 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.test.component.TestConfigProperty;
+
+/**
+ * Unit tests for {@link RoleMappingAugmentor}, covering AWS Cognito role
+ * mapping (browser login via 'cognito:groups' and M2M via the 'scope' claim)
+ * and non-regression of the existing OpenShift/Keycloak claim paths.
+ */
+@QuarkusComponentTest
+@TestConfigProperty(key = "exploitiq.security.oidc.scope-role-mappings", value = "exploitiq-resource-server/exploitiq-api-access=exploitiq-api-access")
+@TestConfigProperty(key = "exploitiq.security.service-account-roles", value = "system:serviceaccount:exploit-iq:exploit-iq-sa,exploitiq-api-access")
+class RoleMappingAugmentorTest {
+
+    @Inject
+    RoleMappingAugmentor augmentor;
+
+    @Test
+    void cognitoGroupMatchingTargetRole_isGranted() {
+        SecurityIdentity result = augment(Map.of("cognito:groups", List.of("exploit-iq-admin")));
+        assertTrue(result.getRoles().contains("exploit-iq-admin"));
+    }
+
+    @Test
+    void cognitoGroupNotMatchingTargetRole_isNotGranted() {
+        SecurityIdentity result = augment(Map.of("cognito:groups", List.of("not-a-configured-role")));
+        assertTrue(result.getRoles().isEmpty());
+    }
+
+    @Test
+    void missingCognitoGroupsClaim_doesNotAffectOpenShiftGroupsMapping() {
+        SecurityIdentity result = augment(Map.of("groups", List.of("exploit-iq-view")));
+        assertTrue(result.getRoles().contains("exploit-iq-view"));
+    }
+
+    @Test
+    void keycloakRealmRoles_stillMapped() {
+        JsonObject realmAccess = Json.createObjectBuilder()
+                .add("roles", Json.createArrayBuilder().add("exploit-iq-prodsec").build())
+                .build();
+        SecurityIdentity result = augment(Map.of("realm_access", realmAccess));
+        assertTrue(result.getRoles().contains("exploit-iq-prodsec"));
+    }
+
+    @Test
+    void keycloakClientRoles_stillMapped() {
+        JsonObject clientAccess = Json.createObjectBuilder()
+                .add("roles", Json.createArrayBuilder().add("exploit-iq-admin").build())
+                .build();
+        JsonObject resourceAccess = Json.createObjectBuilder()
+                .add("exploit-iq-client", clientAccess)
+                .build();
+        SecurityIdentity result = augment(Map.of("resource_access", resourceAccess));
+        assertTrue(result.getRoles().contains("exploit-iq-admin"));
+    }
+
+    @Test
+    void kubernetesServiceAccount_stillMappedWhenNoGroupsClaim() {
+        JsonObject serviceAccount = Json.createObjectBuilder().add("name", "exploit-iq-sa").build();
+        JsonObject kubernetesIo = Json.createObjectBuilder().add("serviceaccount", serviceAccount).build();
+        SecurityIdentity result = augment(Map.of(
+                "kubernetes.io", kubernetesIo,
+                "sub", "system:serviceaccount:exploit-iq:exploit-iq-sa"));
+        assertTrue(result.getRoles().contains("system:serviceaccount:exploit-iq:exploit-iq-sa"));
+    }
+
+    @Test
+    void m2mScopeMatchingConfiguredMapping_isGrantedMappedRole() {
+        SecurityIdentity result = augment(Map.of("scope", "exploitiq-resource-server/exploitiq-api-access"));
+        assertTrue(result.getRoles().contains("exploitiq-api-access"));
+    }
+
+    @Test
+    void m2mScopeWithMultipleValuesMatchingConfiguredMapping_isGrantedMappedRole() {
+        SecurityIdentity result = augment(Map.of("scope", "openid exploitiq-resource-server/exploitiq-api-access"));
+        assertTrue(result.getRoles().contains("exploitiq-api-access"));
+    }
+
+    @Test
+    void m2mScopeNotMatchingConfiguredMapping_isNotGranted() {
+        SecurityIdentity result = augment(Map.of("scope", "some-other-resource-server/some-other-scope"));
+        assertFalse(result.getRoles().contains("exploitiq-api-access"));
+    }
+
+    private SecurityIdentity augment(Map<String, Object> claims) {
+        JsonWebToken jwt = new FakeJsonWebToken(claims);
+        SecurityIdentity identity = QuarkusSecurityIdentity.builder().setPrincipal(jwt).build();
+        return augmentor.augment(identity, null).await().indefinitely();
+    }
+
+    /** Minimal {@link JsonWebToken} test double backed by a claim map. */
+    static class FakeJsonWebToken implements JsonWebToken {
+
+        private final Map<String, Object> claims;
+
+        FakeJsonWebToken(Map<String, Object> claims) {
+            this.claims = claims;
+        }
+
+        @Override
+        public String getName() {
+            return "test-principal";
+        }
+
+        @Override
+        public Set<String> getClaimNames() {
+            return claims.keySet();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getClaim(String claimName) {
+            return (T) claims.get(claimName);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add AWS Cognito support on the existing `external-idp` profile (no new Quarkus profile).
- Map browser-login roles from the `cognito:groups` JWT claim in `RoleMappingAugmentor`.
- Add optional `exploitiq.security.oidc.scope-role-mappings` for Cognito M2M (`client_credentials`) tokens that have no group claim, so agents can be authorized as `exploitiq-api-access`.
- Document required Cognito env vars in `application.properties`.
- Add unit tests for Cognito claim mapping and non-regression of OpenShift/Keycloak/k8s SA paths.

## Out of scope
- `exploit-iq-agent` / vulnerability-analysis Cognito token client (separate repo).
- Changes to OpenShift `prod` or Keycloak flows.

## Test plan
- [x] `mvn test -Dtest=RoleMappingAugmentorTest,RoleMappingAugmentorScopeMappingsUnconfiguredTest`
- [x] Local `QUARKUS_PROFILE=dev,external-idp` with real Cognito User Pool: browser login works and roles from Cognito groups authorize the UI
- [ ] Confirm Keycloak/`prod` behavior unchanged when Cognito env vars / scope mappings are unset
- [x] (Optional) M2M: Cognito `client_credentials` token with configured scope mapping can call the API as `exploitiq-api-access`

[Jira](https://redhat.atlassian.net/browse/APPENG-5865)


