### PR TITLE
fix: bump runtime base image to ubi9/ubi-minimal:9.8-1785339117

### DIFF
--- a/src/main/docker/Dockerfile.multi-stage
+++ b/src/main/docker/Dockerfile.multi-stage
@@ -28,7 +28,7 @@ RUN curl -sSfL "https://github.com/anchore/syft/releases/download/v${SYFT_VERSIO
   && rm /tmp/syft.tar.gz
 
 ## Stage 2 : create the docker final image
-FROM registry.redhat.io/ubi9/ubi-minimal:9.7
+FROM registry.redhat.io/ubi9/ubi-minimal:9.8-1785339117
 
 LABEL description="Red Hat ExploitIQ - UI"
 LABEL io.k8s.description="Red Hat ExploitIQ - UI"


### PR DESCRIPTION
Bump runtime base image from `ubi9/ubi-minimal:9.7` to `ubi9/ubi-minimal:9.8-1785339117` in Dockerfile.multi-stage. 
The patched packages are not yet available in `ubi9/ubi-minimal:9.7` which still ships the vulnerable versions. All packages are patched in `ubi9/ubi-minimal:9.8`