### PR TITLE
TC-5489: count SBOM product scans once toward per-user queue limit

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/ReportService.java
@@ -557,8 +557,9 @@ public class ReportService {
    */
   public ReportData saveAndSubmitNew(ReportData reportData) throws JsonProcessingException, IOException {
     String user = determineUser(reportData.report());
+    String productId = extractProductId(reportData.report());
     try {
-      return queueService.runIfHasCapacity(user, () -> {
+      return queueService.runIfHasCapacity(user, productId, () -> {
         try {
           ReportData saved = saveReport(reportData);
           submit(saved.reportRequestId().id(), saved.report());
@@ -576,16 +577,27 @@ public class ReportService {
   }
 
   private String determineUser(JsonNode report) {
-    JsonNode metadata = report.get("metadata");
-    if (metadata != null && metadata.has("product_id")) {
-      String productId = metadata.get("product_id").asText();
+    String productId = extractProductId(report);
+    if (productId != null) {
       String productUser = productService.getUserName(productId);
       if (productUser != null && !productUser.isEmpty()) {
         return productUser;
       }
     }
-    
+
     return userService.getUserName();
+  }
+
+  private static String extractProductId(JsonNode report) {
+    if (report == null) {
+      return null;
+    }
+    JsonNode metadata = report.get("metadata");
+    if (metadata == null || !metadata.has("product_id") || metadata.get("product_id").isNull()) {
+      return null;
+    }
+    String productId = metadata.get("product_id").asText();
+    return productId != null && !productId.isBlank() ? productId : null;
   }
 
   /**

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueService.java
@@ -15,9 +15,7 @@
 package com.redhat.ecosystemappeng.exploitiq.service;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -59,6 +57,7 @@ public class RequestQueueService {
   private static final Logger LOGGER = Logger.getLogger(RequestQueueService.class);
 
   private static final String DEFAULT_USER = "anonymous";
+  private static final String PRODUCT_ID = "product_id";
 
   @ConfigProperty(name = "exploit-iq.queue.max-active", defaultValue = "5")
   Integer maxActive;
@@ -84,13 +83,20 @@ public class RequestQueueService {
   @Inject
   Tracer tracer;
 
-  private record PendingRequest(String id, String user) {}
+  /** {@code productId} is null for standalone (non-SBOM) reports. */
+  private record PendingRequest(String id, String user, String productId) {}
 
   private Queue<PendingRequest> pending = new ConcurrentLinkedQueue<>();
   private Map<String, LocalDateTime> active = new ConcurrentHashMap<>();
   private Map<String, String> activeUserById = new ConcurrentHashMap<>();
   private Map<String, Set<String>> activeByUser = new ConcurrentHashMap<>();
   private Map<String, Set<String>> pendingByUser = new ConcurrentHashMap<>();
+  /** Report id → product id for in-flight SBOM/product reports. */
+  private Map<String, String> productIdByReportId = new ConcurrentHashMap<>();
+  /** Product id → in-flight report ids (active + pending). */
+  private Map<String, Set<String>> inflightReportsByProduct = new ConcurrentHashMap<>();
+  /** User → distinct in-flight product ids (each counts as one per-user slot). */
+  private Map<String, Set<String>> productsByUser = new ConcurrentHashMap<>();
   // Lock striping: each user gets its own lock so that admission/promotion for one user never
   // blocks another. Entries are intentionally never removed (safe lock-striping doesn't allow
   // pruning while another thread might still hold/await the same lock); the map is bounded by
@@ -122,39 +128,33 @@ public class RequestQueueService {
     expired.forEach(this::removeActive);
     lastCheck = LocalDateTime.now();
     moveToActive();
-    LOGGER.debugf("queue sizes on checkQueue: pending: %d, active: %d, activeUserById: %d, activeByUser: %d, pendingByUser: %d", 
-                pending.size(), active.size(), activeUserById.size(), activeByUser.size(), pendingByUser.size());
-    if (activeByUser.size() != 0) {
-      LOGGER.debugf("activeByUser map contents:");
-      activeByUser.forEach((user, requestIds) -> {
-        if (!requestIds.isEmpty()) {
-          LOGGER.debugf("  user: %s, active requests count: %d", user, requestIds.size());
-        }
-      });
-    }
-    if (pendingByUser.size() != 0) {
-      LOGGER.debugf("pendingByUser map contents:");
-      pendingByUser.forEach((user, requestIds) -> {
-        if (!requestIds.isEmpty()) {
-          LOGGER.debugf("  user: %s, pending requests count: %d", user, requestIds.size());
-        }
-      });
-    }
+    LOGGER.debugf(
+        "queue sizes on checkQueue: pending: %d, active: %d, activeUserById: %d, activeByUser: %d, pendingByUser: %d, productsByUser: %d, inflightReportsByProduct: %d",
+        pending.size(), active.size(), activeUserById.size(), activeByUser.size(), pendingByUser.size(),
+        productsByUser.size(), inflightReportsByProduct.size());
+    logPerUserMaps();
   }
 
 
   @PostConstruct
   void loadExistingQueue() {
   //      Load all queued reports
-    repository.list(Map.of("status", "queued"), Collections.emptyList(), new Pagination(0, maxSize)).results.forEach(r -> trackPending(r.id(), resolveUser(r)));
+    repository.list(Map.of("status", "queued"), Collections.emptyList(), new Pagination(0, maxSize)).results
+        .forEach(r -> trackPending(r.id(), resolveUser(r), extractProductId(r)));
     LOGGER.debugf("Loaded %d elements from existing pending queue", pending.size());
   //  Load all active sent reports (not expired yet), will be reloaded to active DS on application restarts, so there will be no orphan reports left in DB that will never become expired
     repository.list(Map.of("status", "sent"), Collections.emptyList(), new Pagination(0, maxSize))
               .results
-              .forEach(r -> trackActive(r.id(), resolveUser(r), getSubmittedTS(r)));
+              .forEach(r -> trackActive(r.id(), resolveUser(r), getSubmittedTS(r), extractProductId(r)));
     LOGGER.debugf("Loaded %d elements from existing actives Map", active.size());
-    LOGGER.debugf("queue sizes on loadExistingQueue: pending: %d, active: %d, activeUserById: %d, activeByUser: %d, pendingByUser: %d", 
-                pending.size(), active.size(), activeUserById.size(), activeByUser.size(), pendingByUser.size());    
+    LOGGER.debugf(
+        "queue sizes on loadExistingQueue: pending: %d, active: %d, activeUserById: %d, activeByUser: %d, pendingByUser: %d, productsByUser: %d, inflightReportsByProduct: %d",
+        pending.size(), active.size(), activeUserById.size(), activeByUser.size(), pendingByUser.size(),
+        productsByUser.size(), inflightReportsByProduct.size());
+    logPerUserMaps();
+  }
+
+  private void logPerUserMaps() {
     if (activeByUser.size() != 0) {
       LOGGER.debugf("activeByUser map contents:");
       activeByUser.forEach((user, requestIds) -> {
@@ -168,6 +168,14 @@ public class RequestQueueService {
       pendingByUser.forEach((user, requestIds) -> {
         if (!requestIds.isEmpty()) {
           LOGGER.debugf("  user: %s, pending requests count: %d", user, requestIds.size());
+        }
+      });
+    }
+    if (productsByUser.size() != 0) {
+      LOGGER.debugf("productsByUser map contents:");
+      productsByUser.forEach((user, productIds) -> {
+        if (!productIds.isEmpty()) {
+          LOGGER.debugf("  user: %s, in-flight products count: %d", user, productIds.size());
         }
       });
     }
@@ -239,15 +247,19 @@ public class RequestQueueService {
         // otherwise a concurrent admit() call for this user could observe the pending count
         // already decremented but the active count not yet incremented, and admit one request
         // too many. No need to re-check maxActivePerUser here: moving a request from pending to
-        // active doesn't change this user's active+pending total, only which bucket it's in.
+        // active doesn't change this user's occupancy (standalone active+pending, or product slot).
         synchronized (lockFor(next.user())) {
-          untrackPending(next);
-          trackActive(next.id(), next.user());
+          untrackPendingStandalone(next);
+          trackActive(next.id(), next.user(), LocalDateTime.now(), next.productId());
         }
         sendAsync(next.id(), jsonReport);
       } catch (JsonProcessingException e) {
         LOGGER.error("Unable to submit request", e);
         repository.updateWithError(next.id(), "json-processing-error", e.getMessage());
+      }
+    } else {
+      synchronized (lockFor(next.user())) {
+        leavePending(next);
       }
     }
     span.end();
@@ -262,32 +274,24 @@ public class RequestQueueService {
    */
   public void admit(String id, JsonNode json, String user, Runnable onAdmitted) {
     var effectiveUser = resolveEffectiveUser(user);
+    var productId = extractProductId(json);
     boolean sendNow;
-    // The compound check-then-act below only touches this user's own state (activeByUser/
-    // pendingByUser), so a per-user lock is sufficient - concurrent admission for other users
-    // proceeds without contention. active.size()/pending.size() are read without a lock since
-    // they're global counters where a small race-induced overshoot is harmless.
+    // The compound check-then-act below only touches this user's own state, so a per-user lock
+    // is sufficient - concurrent admission for other users proceeds without contention.
+    // active.size()/pending.size() are read without a lock since they're global counters where
+    // a small race-induced overshoot is harmless.
     synchronized (lockFor(effectiveUser)) {
-      var userActiveCount = activeByUser.getOrDefault(effectiveUser, Collections.emptySet()).size();
-      var userPendingCount = pendingByUser.getOrDefault(effectiveUser, Collections.emptySet()).size();
-      // Cap active + pending combined, not just active: this guarantees that a user can never
-      // accumulate more than maxActivePerUser requests in flight in total, so promoting
-      // pending requests to active (see submitOneReportFromQueue()) can never push a user's
-      // active count past their limit either.
-      if (userActiveCount + userPendingCount >= maxActivePerUser) {
-        LOGGER.debugf("User %s exceeded per-user concurrent request limit of %d", effectiveUser, maxActivePerUser);
-        throw new UserQueueExceededException(maxActivePerUser);
-      }
+      assertUserHasCapacity(effectiveUser, productId);
       if (active.size() >= maxActive) {
         if (pending.size() >= maxSize) {
           throw new RequestQueueExceededException(maxSize);
         }
         // Reserve the per-user slot in the same critical section as the check.
-        trackPending(id, effectiveUser);
+        trackPending(id, effectiveUser, productId);
         sendNow = false;
       } else {
         // Reserve the per-user slot in the same critical section as the check.
-        trackActive(id, effectiveUser);
+        trackActive(id, effectiveUser, LocalDateTime.now(), productId);
         sendNow = true;
       }
     }
@@ -300,9 +304,11 @@ public class RequestQueueService {
       if (sendNow) {
         removeActive(id);
       } else {
-        var request = new PendingRequest(id, effectiveUser);
+        var request = new PendingRequest(id, effectiveUser, productId);
         pending.remove(request);
-        untrackPending(request);
+        synchronized (lockFor(effectiveUser)) {
+          leavePending(request);
+        }
       }
       throw e;
     }
@@ -330,53 +336,146 @@ public class RequestQueueService {
    * {@link #admit(String, JsonNode, String, Runnable)} (which needs the id assigned during
    * persistence), so a small race is possible between the two; {@code admit()} enforces the
    * limits again at that point as the source of truth.
+   *
+   * @param productId optional SBOM product id; when non-null and already in flight for the user,
+   *                  the per-user check allows another component of the same product
    */
-  public <T> T runIfHasCapacity(String user, java.util.function.Supplier<T> action) {
+  public <T> T runIfHasCapacity(String user, String productId, java.util.function.Supplier<T> action) {
     var effectiveUser = resolveEffectiveUser(user);
+    var effectiveProductId = blankToNull(productId);
     synchronized (lockFor(effectiveUser)) {
       if (active.size() >= maxActive && pending.size() >= maxSize) {
         throw new RequestQueueExceededException(maxSize);
       }
-      var userActiveCount = activeByUser.getOrDefault(effectiveUser, Collections.emptySet()).size();
-      var userPendingCount = pendingByUser.getOrDefault(effectiveUser, Collections.emptySet()).size();
-      if (userActiveCount + userPendingCount >= maxActivePerUser) {
-        LOGGER.debugf("User %s exceeded per-user concurrent request limit of %d", effectiveUser, maxActivePerUser);
-        throw new UserQueueExceededException(maxActivePerUser);
-      }
+      assertUserHasCapacity(effectiveUser, effectiveProductId);
     }
     return action.get();
+  }
+
+  private void assertUserHasCapacity(String user, String productId) {
+    // Same product already in flight: no additional per-user slot required.
+    if (productId != null && isProductAlreadyInFlight(user, productId)) {
+      return;
+    }
+    if (userOccupancy(user) >= maxActivePerUser) {
+      LOGGER.debugf("User %s exceeded per-user concurrent request limit of %d", user, maxActivePerUser);
+      throw new UserQueueExceededException(maxActivePerUser);
+    }
+  }
+
+  private int userOccupancy(String user) {
+    int standalone = activeByUser.getOrDefault(user, Collections.emptySet()).size()
+        + pendingByUser.getOrDefault(user, Collections.emptySet()).size();
+    int products = productsByUser.getOrDefault(user, Collections.emptySet()).size();
+    return standalone + products;
+  }
+
+  private boolean isProductAlreadyInFlight(String user, String productId) {
+    return productsByUser.getOrDefault(user, Collections.emptySet()).contains(productId);
   }
 
   private String resolveEffectiveUser(String user) {
     return Objects.nonNull(user) && !user.isBlank() ? user : DEFAULT_USER;
   }
 
-  private void trackActive(String id, String user) {
-    trackActive(id, user, LocalDateTime.now());
+  private static String blankToNull(String value) {
+    return Objects.nonNull(value) && !value.isBlank() ? value : null;
   }
 
-  private void trackActive(String id, String user, LocalDateTime sentAt) {
+  private String extractProductId(JsonNode json) {
+    if (json == null) {
+      return null;
+    }
+    JsonNode metadata = json.get("metadata");
+    if (metadata == null || !metadata.has(PRODUCT_ID) || metadata.get(PRODUCT_ID).isNull()) {
+      return null;
+    }
+    return blankToNull(metadata.get(PRODUCT_ID).asText());
+  }
+
+  private String extractProductId(Report report) {
+    if (report.metadata() == null) {
+      return null;
+    }
+    return blankToNull(report.metadata().get(PRODUCT_ID));
+  }
+
+  private void trackActive(String id, String user, LocalDateTime sentAt, String productId) {
     active.put(id, sentAt);
     activeUserById.put(id, user);
-    activeByUser.computeIfAbsent(user, k -> ConcurrentHashMap.newKeySet()).add(id);
-    LOGGER.debugf(
-        "[trackActive] active map: put id=%s -> sentAt=%s; activeUserById map: put id=%s -> user=%s; activeByUser map: added id=%s to user=%s set",
-        id, sentAt, id, user, id, user);
+    if (productId == null) {
+      activeByUser.computeIfAbsent(user, k -> ConcurrentHashMap.newKeySet()).add(id);
+      LOGGER.debugf(
+          "[trackActive] active map: put id=%s -> sentAt=%s; activeUserById map: put id=%s -> user=%s; activeByUser map: added id=%s to user=%s set",
+          id, sentAt, id, user, id, user);
+    } else {
+      registerProductReport(id, user, productId);
+      LOGGER.debugf(
+          "[trackActive] active map: put id=%s -> sentAt=%s; activeUserById map: put id=%s -> user=%s; product slot: productId=%s",
+          id, sentAt, id, user, productId);
+    }
   }
 
-  private void trackPending(String id, String user) {
-    pending.add(new PendingRequest(id, user));
-    pendingByUser.computeIfAbsent(user, k -> ConcurrentHashMap.newKeySet()).add(id);
-    LOGGER.debugf("[trackPending] pendingByUser map: added id=%s to user=%s set", id, user);
+  private void trackPending(String id, String user, String productId) {
+    pending.add(new PendingRequest(id, user, productId));
+    if (productId == null) {
+      pendingByUser.computeIfAbsent(user, k -> ConcurrentHashMap.newKeySet()).add(id);
+      LOGGER.debugf("[trackPending] pendingByUser map: added id=%s to user=%s set", id, user);
+    } else {
+      registerProductReport(id, user, productId);
+      LOGGER.debugf("[trackPending] product slot: added id=%s for user=%s productId=%s", id, user, productId);
+    }
   }
 
-  private void untrackPending(PendingRequest request) {
+  private void registerProductReport(String id, String user, String productId) {
+    productIdByReportId.put(id, productId);
+    inflightReportsByProduct.computeIfAbsent(productId, k -> ConcurrentHashMap.newKeySet()).add(id);
+    productsByUser.computeIfAbsent(user, k -> ConcurrentHashMap.newKeySet()).add(productId);
+  }
+
+  /** Removes a standalone report from {@code pendingByUser} only (used on pending→active promotion). */
+  private void untrackPendingStandalone(PendingRequest request) {
+    if (request.productId() != null) {
+      return;
+    }
     var ids = pendingByUser.get(request.user());
     if (Objects.nonNull(ids)) {
       ids.remove(request.id());
       if (ids.isEmpty()) {
         pendingByUser.remove(request.user(), ids);
-        LOGGER.debugf("[untrackPending] pendingByUser map: removed id=%s from user=%s set (set now empty, user entry removed)", request.id(), request.user()); 
+        LOGGER.debugf("[untrackPending] pendingByUser map: removed id=%s from user=%s set (set now empty, user entry removed)", request.id(), request.user());
+      }
+    }
+  }
+
+  /** Leaves the pending queue entirely (rollback / missing report), releasing any product slot. */
+  private void leavePending(PendingRequest request) {
+    untrackPendingStandalone(request);
+    if (request.productId() != null) {
+      releaseProductReport(request.id(), request.user());
+    }
+  }
+
+  private void releaseProductReport(String id, String user) {
+    var productId = productIdByReportId.remove(id);
+    if (productId == null) {
+      return;
+    }
+    var reports = inflightReportsByProduct.get(productId);
+    if (Objects.nonNull(reports)) {
+      reports.remove(id);
+      if (reports.isEmpty()) {
+        inflightReportsByProduct.remove(productId, reports);
+        var products = productsByUser.get(user);
+        if (Objects.nonNull(products)) {
+          products.remove(productId);
+          if (products.isEmpty()) {
+            productsByUser.remove(user, products);
+          }
+        }
+        LOGGER.debugf(
+            "[releaseProductReport] last in-flight report %s for product %s left queue; freed product slot for user %s",
+            id, productId, user);
       }
     }
   }
@@ -396,7 +495,7 @@ public class RequestQueueService {
   private void removeActive(String id) {
     active.remove(id);
     // activeUserById.remove(id) atomically resolves and clears the owning user; only the
-    // per-user activeByUser cleanup below needs to be synchronized on that user's lock.
+    // per-user cleanup below needs to be synchronized on that user's lock.
     var user = activeUserById.remove(id);
     if (Objects.nonNull(user)) {
       synchronized (lockFor(user)) {
@@ -405,9 +504,10 @@ public class RequestQueueService {
           ids.remove(id);
           if (ids.isEmpty()) {
             activeByUser.remove(user, ids);
-            LOGGER.debugf("[removeActive] activeByUser map: removed id=%s from user=%s set (set now empty, user entry removed)", id, user);     
+            LOGGER.debugf("[removeActive] activeByUser map: removed id=%s from user=%s set (set now empty, user entry removed)", id, user);
           }
         }
+        releaseProductReport(id, user);
       }
     }
   }

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceQueueAdmissionTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/ReportServiceQueueAdmissionTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -100,7 +101,7 @@ class ReportServiceQueueAdmissionTest {
     ReportData unsaved = new ReportData(new ReportRequestId(null, "scan-x"), report);
 
     doThrow(new RequestQueueExceededException(2))
-        .when(queueService).runIfHasCapacity(any(), any());
+        .when(queueService).runIfHasCapacity(any(), nullable(String.class), any());
 
     assertThrows(RequestQueueExceededException.class, () -> reportService.saveAndSubmitNew(unsaved));
 

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueServiceTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/service/RequestQueueServiceTest.java
@@ -216,6 +216,101 @@ class RequestQueueServiceTest {
     assertThrows(UserQueueExceededException.class, () -> service.queue("alice-4", report, "alice"));
   }
 
+  @Test
+  void queue_sameProductIdCountsAsSingleUserSlot() throws Exception {
+    JsonNode productReport = sampleProductReport("product-a");
+
+    assertDoesNotThrow(() -> service.queue("p-a-1", productReport, "alice"));
+    assertDoesNotThrow(() -> service.queue("p-a-2", productReport, "alice"));
+    assertDoesNotThrow(() -> service.queue("p-a-3", productReport, "alice"));
+
+    // One product slot used; alice can still admit one more distinct slot (standalone or product).
+    assertDoesNotThrow(() -> service.queue("standalone-1", sampleReport(), "alice"));
+    assertThrows(UserQueueExceededException.class, () -> service.queue("standalone-2", sampleReport(), "alice"));
+  }
+
+  @Test
+  void queue_secondDistinctProductIdConsumesAnotherSlot() throws Exception {
+    JsonNode productA = sampleProductReport("product-a");
+    JsonNode productB = sampleProductReport("product-b");
+
+    assertDoesNotThrow(() -> service.queue("p-a-1", productA, "alice"));
+    assertDoesNotThrow(() -> service.queue("p-a-2", productA, "alice"));
+    assertDoesNotThrow(() -> service.queue("p-b-1", productB, "alice"));
+
+    assertThrows(
+        UserQueueExceededException.class,
+        () -> service.queue("p-c-1", sampleProductReport("product-c"), "alice"));
+  }
+
+  @Test
+  void queue_mixesStandaloneAndProductSlotsTowardSameLimit() throws Exception {
+    assertDoesNotThrow(() -> service.queue("standalone-1", sampleReport(), "alice"));
+    assertDoesNotThrow(() -> service.queue("p-a-1", sampleProductReport("product-a"), "alice"));
+    assertDoesNotThrow(() -> service.queue("p-a-2", sampleProductReport("product-a"), "alice"));
+
+    assertThrows(UserQueueExceededException.class, () -> service.queue("standalone-2", sampleReport(), "alice"));
+    assertThrows(
+        UserQueueExceededException.class,
+        () -> service.queue("p-b-1", sampleProductReport("product-b"), "alice"));
+  }
+
+  @Test
+  void queue_freesProductSlotWhenLastInFlightReportIsReceived() throws Exception {
+    JsonNode productA = sampleProductReport("product-a");
+
+    service.queue("p-a-1", productA, "alice");
+    service.queue("p-a-2", productA, "alice");
+    service.queue("standalone-1", sampleReport(), "alice");
+    assertThrows(UserQueueExceededException.class, () -> service.queue("standalone-2", sampleReport(), "alice"));
+
+    service.received("p-a-1");
+    // Product still in flight via p-a-2; still at limit.
+    assertThrows(UserQueueExceededException.class, () -> service.queue("standalone-2", sampleReport(), "alice"));
+
+    service.received("p-a-2");
+    // Product slot freed; alice can queue again.
+    assertDoesNotThrow(() -> service.queue("standalone-2", sampleReport(), "alice"));
+  }
+
+  @Test
+  void queue_productReportsInPendingStillCountOnceTowardUserLimit() throws Exception {
+    JsonNode standalone = sampleReport();
+    JsonNode productA = sampleProductReport("product-a");
+
+    int fillerUsers = MAX_ACTIVE / MAX_ACTIVE_PER_USER;
+    for (int u = 0; u < fillerUsers; u++) {
+      for (int i = 0; i < MAX_ACTIVE_PER_USER; i++) {
+        service.queue("filler-" + u + "-" + i, standalone, "filler-" + u);
+      }
+    }
+
+    assertDoesNotThrow(() -> service.queue("alice-p-1", productA, "alice"));
+    assertDoesNotThrow(() -> service.queue("alice-p-2", productA, "alice"));
+    assertDoesNotThrow(() -> service.queue("alice-standalone", standalone, "alice"));
+
+    assertThrows(
+        UserQueueExceededException.class,
+        () -> service.queue("alice-extra", sampleProductReport("product-b"), "alice"));
+  }
+
+  @Test
+  void runIfHasCapacity_allowsSameProductWhenAlreadyInFlight() throws Exception {
+    JsonNode productA = sampleProductReport("product-a");
+    service.queue("p-a-1", productA, "alice");
+    service.queue("standalone-1", sampleReport(), "alice");
+
+    assertDoesNotThrow(() ->
+        service.runIfHasCapacity("alice", "product-a", () -> "ok"));
+
+    assertThrows(
+        UserQueueExceededException.class,
+        () -> service.runIfHasCapacity("alice", "product-b", () -> "nope"));
+    assertThrows(
+        UserQueueExceededException.class,
+        () -> service.runIfHasCapacity("alice", null, () -> "nope"));
+  }
+
   private JsonNode sampleReport() throws Exception {
     return objectMapper.readTree("""
         {
@@ -224,5 +319,18 @@ class RequestQueueServiceTest {
           }
         }
         """);
+  }
+
+  private JsonNode sampleProductReport(String productId) throws Exception {
+    return objectMapper.readTree("""
+        {
+          "input": {
+            "scan": { "id": "scan-1" }
+          },
+          "metadata": {
+            "product_id": "%s"
+          }
+        }
+        """.formatted(productId));
   }
 }


### PR DESCRIPTION
Deduplicate maxActivePerUser occupancy by metadata.product_id so SPDX/CycloneDX component reports share one user slot, while standalone repo/RPM behavior is unchanged.