### PR TITLE
fix: CVE ID  will not be accepted as package NVR

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/model/NewRpmReportRequest.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/model/NewRpmReportRequest.java
@@ -17,6 +17,7 @@ package com.redhat.ecosystemappeng.exploitiq.model;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.redhat.ecosystemappeng.exploitiq.validation.NotCveIdAsRpmNvr;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
@@ -24,6 +25,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 @Schema(name = "NewRpmReportRequest", description = "RPM package plus CVE for new analysis request")
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @RegisterForReflection
+@NotCveIdAsRpmNvr
 public record NewRpmReportRequest(
     @Schema(required = true, description = "RPM package name") String name,
     @Schema(required = true, description = "RPM package version") String version,

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RpmReportService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/service/RpmReportService.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -38,6 +39,8 @@ import com.redhat.ecosystemappeng.exploitiq.validation.RpmArchitecture;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 
 /**
  * Builds, persists, and submits ExploitIQ report requests for the RPM package checker pipeline.
@@ -53,6 +56,9 @@ public class RpmReportService {
 
   @Inject
   UserService userService;
+
+  @Inject
+  Validator validator;
 
   private record ValidatedNewRpmReport(String name, String version, String release, String arch, String cveUppercase) {
   }
@@ -81,10 +87,24 @@ public class RpmReportService {
     putIfBlank(errors, "arch", arch, "Architecture is required");
     RpmArchitecture.putArchFieldErrorIfNotAllowed(errors, arch);
     CveIdRules.putOfficialCveFieldErrorIfInvalid(errors, request.cveId());
+    putHibernateConstraintViolations(errors, request);
     if (!errors.isEmpty()) {
       throw new ValidationException(errors);
     }
     return new ValidatedNewRpmReport(name, version, release, arch, rawCve.toUpperCase());
+  }
+
+  /**
+   * Merges Hibernate Validator constraint violations (e.g. {@link com.redhat.ecosystemappeng.exploitiq.validation.NotCveIdAsRpmNvr})
+   * into the aggregated field-error map without overwriting earlier messages for the same field.
+   */
+  private void putHibernateConstraintViolations(Map<String, String> errors, NewRpmReportRequest request) {
+    Set<ConstraintViolation<NewRpmReportRequest>> violations = validator.validate(request);
+    for (ConstraintViolation<NewRpmReportRequest> violation : violations) {
+      String path = violation.getPropertyPath() == null ? "" : violation.getPropertyPath().toString();
+      String field = path.isEmpty() ? "name" : path;
+      errors.putIfAbsent(field, violation.getMessage());
+    }
   }
 
   private ReportData generateRpmPackageCheckerReport(ValidatedNewRpmReport v) throws JsonProcessingException {

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/validation/NotCveIdAsRpmNvr.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/validation/NotCveIdAsRpmNvr.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.validation;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+/**
+ * Rejects RPM name/version/release coordinates that reconstruct to an official CVE id
+ * (e.g. {@code CVE} / {@code 2024} / {@code 12345} from pasting a CVE into the Package N-V-R field).
+ */
+@Documented
+@Constraint(validatedBy = NotCveIdAsRpmNvrValidator.class)
+@Target(TYPE)
+@Retention(RUNTIME)
+public @interface NotCveIdAsRpmNvr {
+
+  String message() default "A CVE ID was entered in the Package N-V-R field. Enter the package as name-version-release and put the CVE ID in the CVE ID field.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/validation/NotCveIdAsRpmNvrValidator.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/validation/NotCveIdAsRpmNvrValidator.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.validation;
+
+import java.util.Locale;
+
+import com.redhat.ecosystemappeng.exploitiq.model.NewRpmReportRequest;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * Hibernate Validator implementation for {@link NotCveIdAsRpmNvr}.
+ */
+public class NotCveIdAsRpmNvrValidator implements ConstraintValidator<NotCveIdAsRpmNvr, NewRpmReportRequest> {
+
+  /**
+   * User-facing copy when a CVE id is pasted into Package N-V-R (aligned with Request Analysis UI).
+   */
+  public static final String MESSAGE =
+      "A CVE ID was entered in the Package N-V-R field. Enter the package as name-version-release "
+          + "and put the CVE ID in the CVE ID field.";
+
+  @Override
+  public boolean isValid(NewRpmReportRequest value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return true;
+    }
+    String name = trimmedOrNull(value.name());
+    String version = trimmedOrNull(value.version());
+    String release = trimmedOrNull(value.release());
+    if (name == null || version == null || release == null) {
+      return true;
+    }
+    String reconstructedNvr = name + "-" + version + "-" + release;
+    if (!isOfficialCveId(reconstructedNvr)) {
+      return true;
+    }
+    if (context != null) {
+      context.disableDefaultConstraintViolation();
+      context.buildConstraintViolationWithTemplate(MESSAGE)
+          .addPropertyNode("name")
+          .addConstraintViolation();
+    }
+    return false;
+  }
+
+  /** {@code true} when {@code value} matches the official CVE pattern (case-insensitive). */
+  public static boolean isOfficialCveId(String value) {
+    String trimmed = trimmedOrNull(value);
+    if (trimmed == null) {
+      return false;
+    }
+    return CveIdRules.OFFICIAL_CVE_PATTERN.matcher(trimmed.toUpperCase(Locale.ROOT)).matches();
+  }
+
+  private static String trimmedOrNull(String s) {
+    if (s == null) {
+      return null;
+    }
+    String t = s.trim();
+    return t.isEmpty() ? null : t;
+  }
+}

--- a/src/main/webui/src/hooks/useAnalysisRequestForm.ts
+++ b/src/main/webui/src/hooks/useAnalysisRequestForm.ts
@@ -19,7 +19,9 @@ import {
 import {
   parseTrimmedRpmNvr,
   validateRpmPackageNvrBlur,
+  isCveIdAsPackageNvr,
   RPM_PACKAGE_NVR_FORMAT_ERROR_MESSAGE,
+  RPM_PACKAGE_NVR_CVE_ID_ERROR_MESSAGE,
   DEFAULT_RPM_ARCH,
   isRpmArchChoice,
   type RpmArchChoice,
@@ -187,6 +189,8 @@ function getClientValidationErrors(s: AnalysisRequestStoredValues): Partial<Anal
     const pkg = s.rpmPackageNvr.trim();
     if (pkg === "") {
       errors.rpmPackageNvr = VALIDATION_MESSAGE_REQUIRED;
+    } else if (isCveIdAsPackageNvr(pkg)) {
+      errors.rpmPackageNvr = RPM_PACKAGE_NVR_CVE_ID_ERROR_MESSAGE;
     } else if (!parseTrimmedRpmNvr(pkg)) {
       errors.rpmPackageNvr = RPM_PACKAGE_NVR_FORMAT_ERROR_MESSAGE;
     }
@@ -375,6 +379,13 @@ export function useAnalysisRequestForm({
   const onTextChange = useCallback(
     (field: AnalysisRequestFormTextField, _event: React.FormEvent<HTMLInputElement>, value: string) => {
       setValues((prev) => ({ ...prev, [field]: value }));
+      if (field === "rpmPackageNvr") {
+        setErrors((prev) => ({
+          ...prev,
+          rpmPackageNvr: isCveIdAsPackageNvr(value) ? RPM_PACKAGE_NVR_CVE_ID_ERROR_MESSAGE : null,
+        }));
+        return;
+      }
       setErrors((prev) => (prev[field] ? { ...prev, [field]: null } : prev));
     },
     []
@@ -577,6 +588,13 @@ export function useAnalysisRequestForm({
       setState({ isSubmitting: true });
       try {
         const trimmedPkg = values.rpmPackageNvr.trim();
+        if (isCveIdAsPackageNvr(trimmedPkg)) {
+          setErrors((prev) => ({
+            ...prev,
+            rpmPackageNvr: RPM_PACKAGE_NVR_CVE_ID_ERROR_MESSAGE,
+          }));
+          return;
+        }
         const coords = parseTrimmedRpmNvr(trimmedPkg);
         if (!coords) {
           setErrors((prev) => ({
@@ -655,7 +673,9 @@ export function useAnalysisRequestForm({
     state.isSubmitting ||
     (values.mode !== "rpm" &&
       values.isAuthenticationSecretChecked &&
-      values.authenticationSecret.trim() === "");
+      values.authenticationSecret.trim() === "") ||
+    (values.mode === "rpm" &&
+      (isCveIdAsPackageNvr(values.rpmPackageNvr) || errors.rpmPackageNvr !== null));
 
   const { selectedFile: _selectedFile, ...exportedValues } = values;
 

--- a/src/main/webui/src/utils/requestAnalysisRpm.ts
+++ b/src/main/webui/src/utils/requestAnalysisRpm.ts
@@ -2,10 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { NewRpmReportRequest } from "../generated-client/models/NewRpmReportRequest";
+import { CVE_ID_PATTERN } from "./requestAnalysisValidation";
 
 /** Shown when the package string cannot be split into nonempty name, version, and release (RPM-style split from the right). */
 export const RPM_PACKAGE_NVR_FORMAT_ERROR_MESSAGE =
   "Enter the package as name-version-release (for example openssl-3.0.7-5.el9), with hyphens separating all three parts.";
+
+/**
+ * Aligned with backend {@code NotCveIdAsRpmNvrValidator.MESSAGE} — CVE pasted into Package N-V-R.
+ */
+export const RPM_PACKAGE_NVR_CVE_ID_ERROR_MESSAGE =
+  "A CVE ID was entered in the Package N-V-R field. Enter the package as name-version-release and put the CVE ID in the CVE ID field.";
 
 export type RpmArchChoice = NewRpmReportRequest["arch"];
 
@@ -39,6 +46,18 @@ function isValidRpmVersionOrRelease(value: string): boolean {
   return RPM_VERSION_RELEASE_PATTERN.test(value);
 }
 
+/**
+ * {@code true} when the trimmed value matches an official CVE id (case-insensitive),
+ * i.e. a CVE was pasted into Package N-V-R instead of name-version-release.
+ */
+export function isCveIdAsPackageNvr(raw: string): boolean {
+  const t = raw.trim();
+  if (t === "") {
+    return false;
+  }
+  return CVE_ID_PATTERN.test(t.toUpperCase());
+}
+
 /** Parses a trimmed RPM N-V-R: release after last hyphen, version before that, name is the leading remainder (may contain hyphens). */
 export function parseTrimmedRpmNvr(
   trimmed: string
@@ -64,11 +83,18 @@ export function parseTrimmedRpmNvr(
   return { name, version, release };
 }
 
-/** Blur-only: empty yields no format error ("Required" is enforced on submit). */
+/**
+ * Blur/submit format check for Package N-V-R.
+ * Empty yields no format error ("Required" is enforced on submit).
+ * Rejects CVE ids pasted into this field (backend {@code @NotCveIdAsRpmNvr}).
+ */
 export function validateRpmPackageNvrBlur(raw: string): string | null {
   const t = raw.trim();
   if (t === "") {
     return null;
+  }
+  if (isCveIdAsPackageNvr(t)) {
+    return RPM_PACKAGE_NVR_CVE_ID_ERROR_MESSAGE;
   }
   return parseTrimmedRpmNvr(t) ? null : RPM_PACKAGE_NVR_FORMAT_ERROR_MESSAGE;
 }

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/NewRpmReportRestTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/NewRpmReportRestTest.java
@@ -150,6 +150,27 @@ class NewRpmReportRestTest {
     }
 
     @Test
+    void cveIdAsPackageNameVersionReleaseReturns400() {
+        Map<String, String> body = Map.of(
+            "name", "CVE",
+            "version", "2016",
+            "release", "8687",
+            "arch", "x86_64",
+            "cveId", VALID_CVE);
+
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .body(body)
+            .when()
+            .post(PATH)
+            .then()
+            .statusCode(400)
+            .body("errors.name", equalTo(
+                "A CVE ID was entered in the Package N-V-R field. Enter the package as name-version-release "
+                    + "and put the CVE ID in the CVE ID field."));
+    }
+
+    @Test
     void i686ArchitectureIsAccepted() {
         Map<String, String> body = new HashMap<>(baseValidBody());
         body.put("arch", "i686");

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/validation/NotCveIdAsRpmNvrValidatorTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/validation/NotCveIdAsRpmNvrValidatorTest.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.ecosystemappeng.exploitiq.model.NewRpmReportRequest;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+
+class NotCveIdAsRpmNvrValidatorTest {
+
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUpValidator() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @Test
+  void rejectsCoordinatesThatReconstructToOfficialCveId() {
+    NewRpmReportRequest request = new NewRpmReportRequest("CVE", "2016", "8687", "x86_64", "CVE-2016-8687");
+
+    Set<ConstraintViolation<NewRpmReportRequest>> violations = validator.validate(request);
+
+    assertEquals(1, violations.size());
+    ConstraintViolation<NewRpmReportRequest> violation = violations.iterator().next();
+    assertEquals("name", violation.getPropertyPath().toString());
+    assertEquals(NotCveIdAsRpmNvrValidator.MESSAGE, violation.getMessage());
+  }
+
+  @Test
+  void rejectsLowercaseCvePastedAsNvr() {
+    NewRpmReportRequest request = new NewRpmReportRequest("cve", "2024", "12345", "x86_64", "CVE-2024-12345");
+
+    Set<ConstraintViolation<NewRpmReportRequest>> violations = validator.validate(request);
+
+    assertFalse(violations.isEmpty());
+  }
+
+  @Test
+  void acceptsNormalRpmCoordinates() {
+    NewRpmReportRequest request =
+        new NewRpmReportRequest("libarchive", "3.1.2", "14.el7_9.1", "x86_64", "CVE-2016-8687");
+
+    assertTrue(validator.validate(request).isEmpty());
+  }
+
+  @Test
+  void skipsWhenCoordinatesIncomplete() {
+    NewRpmReportRequest request = new NewRpmReportRequest("CVE", "2016", "  ", "x86_64", "CVE-2016-8687");
+
+    assertTrue(validator.validate(request).isEmpty());
+  }
+}


### PR DESCRIPTION
Fixes: https://redhat.atlassian.net/browse/TC-5542 

A CVE ID like `CVE-2024-12345` was being accepted as Package N-V-R because it parses as `name=CVE`, `version=2024`, `release=12345`.

### Backend (Hibernate Validator)
- Added `@NotCveIdAsRpmNvr` on `NewRpmReportRequest`
- Validator rejects when `name-version-release` matches an official CVE ID
- `RpmReportService` merges those violations into the existing `{ errors: { name: "..." } }` response (400)

### Frontend
- Same check on Package N-V-R (on change / blur / submit)
- Shows: *"A CVE ID was entered in the Package N-V-R field…"*
- Disables **Submit Analysis Request** when that happens

### Test
 `NotCveIdAsRpmNvrValidatorTest`
 
 Before:
 
<img width="440" height="259" alt="image" src="https://github.com/user-attachments/assets/911e6289-e768-4e07-8b87-ab49a4046ff1" />

 After:
<img width="440" height="259" alt="image" src="https://github.com/user-attachments/assets/abd09ec8-3463-46ae-8044-1481407b78ae" />
