### PR TITLE
fix: implement custom Cognito logout to use correct parameters

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -29,7 +29,6 @@ import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 import com.redhat.ecosystemappeng.exploitiq.service.UserService;
 
 import java.net.MalformedURLException;
@@ -77,7 +76,6 @@ public class TokenResource {
 
         if (cognitoDomain.isPresent() && clientId.isPresent()) {
             String domain = cognitoDomain.get().trim();
-
             // Validate domain is not empty or just "/"
             if (domain.isEmpty() || domain.equals("/")) {
                 LOG.warnf("User %s: Cognito domain configured but invalid after trim ('%s'), falling back to local logout",
@@ -136,25 +134,9 @@ public class TokenResource {
         try {
             return userService.getUserName();
         } catch (Exception e) {
+            LOG.debugf(e, "Could not retrieve username for logging");
             return "anonymous";
         }
-    }
-
-    /**
-     * Exception mapper for logout-related exceptions.
-     * Handles any unexpected errors during logout by falling back to local logout HTML.
-     */
-    @ServerExceptionMapper
-    public Response mapLogoutException(Exception e) {
-        // Only handle exceptions from logout endpoints
-        if (e.getStackTrace().length > 0 &&
-            e.getStackTrace()[0].getMethodName().equals("logout") ||
-            e.getStackTrace()[0].getMethodName().equals("loggedOut")) {
-            LOG.errorf(e, "Unexpected error during logout, falling back to local logout page");
-            return buildLogoutResponse(Response.ok(LOGGED_OUT_HTML));
-        }
-        // Let other exceptions be handled by default handlers
-        return null;
     }
 
     /**

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -21,17 +21,31 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import com.redhat.ecosystemappeng.exploitiq.service.UserService;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 @Path("/user")
 public class TokenResource {
 
     @Inject
     UserService userService;
+
+    @ConfigProperty(name = "quarkus.oidc.auth-server-url")
+    Optional<String> authServerUrl;
+
+    @ConfigProperty(name = "quarkus.oidc.client-id")
+    Optional<String> clientId;
 
     @GET
     @Produces("application/json")
@@ -41,16 +55,47 @@ public class TokenResource {
     }
 
     /**
-     * Performs a local logout using the standard 'Clear-Site-Data' header.
-     * This feature is available only in secure contexts (HTTPS)
-     * https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data
+     * Logout endpoint with AWS Cognito support.
+     * For Cognito (when auth-server-url contains cognito-idp), redirects to Cognito's logout endpoint.
+     * For other OIDC providers, performs local logout with Clear-Site-Data header.
      */
     @POST
     @Path("/logout")
     @Produces(MediaType.TEXT_HTML)
     @Operation(hidden = true)
     @PermitAll
-    public Response logout() {
+    public Response logout(@Context UriInfo uriInfo) {
+        // Check if we're using AWS Cognito
+        boolean isCognito = authServerUrl.isPresent() && authServerUrl.get().contains("cognito-idp");
+
+        if (isCognito && clientId.isPresent()) {
+            // Build Cognito logout URL
+            // Extract Cognito domain from auth server URL
+            // auth-server-url format: https://cognito-idp.{region}.amazonaws.com/{user-pool-id}
+            // Cognito domain format: https://{region}{user-pool-id}.auth.{region}.amazoncognito.com
+            String authUrl = authServerUrl.get();
+            String region = authUrl.substring(authUrl.indexOf("cognito-idp.") + 12, authUrl.indexOf(".amazonaws.com"));
+            String userPoolId = authUrl.substring(authUrl.lastIndexOf("/") + 1);
+
+            // Build Cognito domain (remove hyphens from user pool ID for domain)
+            String cognitoDomain = String.format("https://%s%s.auth.%s.amazoncognito.com",
+                    region, userPoolId.replace("_", "").replace("-", "").toLowerCase(), region);
+
+            // Build logout redirect URI (current app base URL)
+            String logoutRedirectUri = uriInfo.getBaseUri().toString();
+
+            // Build Cognito logout URL with required parameters
+            String cognitoLogoutUrl = String.format("%s/logout?client_id=%s&logout_uri=%s",
+                    cognitoDomain,
+                    clientId.get(),
+                    URLEncoder.encode(logoutRedirectUri, StandardCharsets.UTF_8));
+
+            return Response.seeOther(URI.create(cognitoLogoutUrl))
+                    .header("Clear-Site-Data", "\"cookies\", \"storage\"")
+                    .build();
+        }
+
+        // For non-Cognito providers, perform local logout
         return Response.ok(LOGGED_OUT_HTML)
                 .header("Clear-Site-Data", "\"cookies\", \"storage\"")
                 .build();

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -130,9 +130,6 @@ public class TokenResource {
     private Response buildLogoutResponse(Response.ResponseBuilder responseBuilder) {
         return responseBuilder
                 .header("Clear-Site-Data", "\"cookies\", \"storage\"")
-//                .header("Cache-Control", "no-cache, no-store, must-revalidate")
-//                .header("Pragma", "no-cache")
-//                .header("Expires", "0")
                 .build();
     }
 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -84,7 +84,7 @@ public class TokenResource {
             // Validate URL structure before extracting region
             if (cognitoIdpIndex == -1 || amazonawsIndex == -1) {
                 // Fallback to local logout if URL doesn't match expected Cognito format
-                return createLocalLogoutResponse();
+                return buildLogoutResponse(Response.ok(LOGGED_OUT_HTML));
             }
 
             String region = authUrl.substring(cognitoIdpIndex + 12, amazonawsIndex);
@@ -105,17 +105,15 @@ public class TokenResource {
                     clientId.get(),
                     URLEncoder.encode(logoutRedirectUri, StandardCharsets.UTF_8));
 
-            return Response.seeOther(URI.create(cognitoLogoutUrl))
-                    .header("Clear-Site-Data", "\"cookies\", \"storage\"")
-                    .build();
+            return buildLogoutResponse(Response.seeOther(URI.create(cognitoLogoutUrl)));
         }
 
         // For non-Cognito providers, perform local logout
-        return createLocalLogoutResponse();
+        return buildLogoutResponse(Response.ok(LOGGED_OUT_HTML));
     }
 
-    private Response createLocalLogoutResponse() {
-        return Response.ok(LOGGED_OUT_HTML)
+    private Response buildLogoutResponse(Response.ResponseBuilder responseBuilder) {
+        return responseBuilder
                 .header("Clear-Site-Data", "\"cookies\", \"storage\"")
                 .build();
     }

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -47,6 +47,9 @@ public class TokenResource {
     @ConfigProperty(name = "quarkus.oidc.client-id")
     Optional<String> clientId;
 
+    @ConfigProperty(name = "cognito.domain")
+    Optional<String> cognitoDomain;
+
     @GET
     @Produces("application/json")
     @Operation(hidden = true)
@@ -56,7 +59,7 @@ public class TokenResource {
 
     /**
      * Logout endpoint with AWS Cognito support.
-     * For Cognito (when auth-server-url contains cognito-idp), redirects to Cognito's logout endpoint.
+     * For Cognito (when cognito.domain is configured), redirects to Cognito's logout endpoint.
      * For other OIDC providers, performs local logout with Clear-Site-Data header.
      *
      * NOTE: Cognito behind a reverse proxy is not currently supported.
@@ -67,33 +70,13 @@ public class TokenResource {
     @Operation(hidden = true)
     @PermitAll
     public Response logout(@Context UriInfo uriInfo) {
-        // Invalidate the OIDC session on the server side
-        // Check if we're using AWS Cognito
-        boolean isCognito = authServerUrl.isPresent() && authServerUrl.get().contains("cognito-idp");
 
-        if (isCognito && clientId.isPresent()) {
-            // Build Cognito logout URL
-            // Extract Cognito domain from auth server URL
-            // auth-server-url format: https://cognito-idp.{region}.amazonaws.com/{user-pool-id}
-            // user-pool-id format: {region}_{random-string}, e.g., eu-north-1_rIW9qmUNl
-            // Cognito domain format: https://{region-lowercase}{random-string-lowercase}.auth.{region}.amazoncognito.com
-            // Example: eu-north-1_rIW9qmUNl -> eu-north-1riw9qmunl.auth.eu-north-1.amazoncognito.com
-            String authUrl = authServerUrl.get();
-            int cognitoIdpIndex = authUrl.indexOf("cognito-idp.");
-            int amazonawsIndex = authUrl.indexOf(".amazonaws.com");
+        if (cognitoDomain.isPresent()) {
+            String domain = cognitoDomain.get().trim();
 
-            // Validate URL structure before extracting region
-            if (cognitoIdpIndex == -1 || amazonawsIndex == -1) {
-                // Fallback to local logout if URL doesn't match expected Cognito format
-                return buildLogoutResponse(Response.ok(LOGGED_OUT_HTML));
+            if (domain.endsWith("/")) {
+                domain = domain.substring(0, domain.length() - 1);
             }
-
-            String region = authUrl.substring(cognitoIdpIndex + 12, amazonawsIndex);
-            String userPoolId = authUrl.substring(authUrl.lastIndexOf("/") + 1);
-
-            // Build Cognito domain: replace underscore with nothing, keep hyphens, convert to lowercase
-            String cognitoDomain = String.format("https://%s.auth.%s.amazoncognito.com",
-                    userPoolId.replace("_", "").toLowerCase(), region);
 
             // Build logout redirect URI to the logged-out page
             // uriInfo.getBaseUri() returns https://host/api/v1/, we need https://host/api/v1/user/logged-out
@@ -102,7 +85,7 @@ public class TokenResource {
 
             // Build Cognito logout URL with required parameters
             String cognitoLogoutUrl = String.format("%s/logout?client_id=%s&logout_uri=%s",
-                    cognitoDomain,
+                    domain,
                     clientId.get(),
                     URLEncoder.encode(logoutRedirectUri, StandardCharsets.UTF_8));
 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -28,9 +28,13 @@ import jakarta.ws.rs.core.UriInfo;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 import com.redhat.ecosystemappeng.exploitiq.service.UserService;
 
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -38,11 +42,10 @@ import java.util.Optional;
 @Path("/user")
 public class TokenResource {
 
+    private static final Logger LOG = Logger.getLogger(TokenResource.class);
+
     @Inject
     UserService userService;
-
-    @ConfigProperty(name = "quarkus.oidc.auth-server-url")
-    Optional<String> authServerUrl;
 
     @ConfigProperty(name = "quarkus.oidc.client-id")
     Optional<String> clientId;
@@ -62,7 +65,7 @@ public class TokenResource {
      * For Cognito (when cognito.domain is configured), redirects to Cognito's logout endpoint.
      * For other OIDC providers, performs local logout with Clear-Site-Data header.
      *
-     * NOTE: Cognito behind a reverse proxy is not currently supported.
+     * NOTE: Cognito behind a reverse proxy is currently not supported.
      */
     @POST
     @Path("/logout")
@@ -70,12 +73,31 @@ public class TokenResource {
     @Operation(hidden = true)
     @PermitAll
     public Response logout(@Context UriInfo uriInfo) {
+        String username = getUsernameForLogging();
 
-        if (cognitoDomain.isPresent()) {
+        if (cognitoDomain.isPresent() && clientId.isPresent()) {
             String domain = cognitoDomain.get().trim();
 
+            // Validate domain is not empty or just "/"
+            if (domain.isEmpty() || domain.equals("/")) {
+                LOG.warnf("User %s: Cognito domain configured but invalid after trim ('%s'), falling back to local logout",
+                         username, domain);
+                return performLocalLogout(username);
+            }
+
+            // Strip trailing slash
             if (domain.endsWith("/")) {
-                domain = domain.substring(0, domain.length() - 1);
+                StringBuilder domainSb = new StringBuilder(domain);
+                domainSb.deleteCharAt(domainSb.length() - 1);
+                domain = domainSb.toString();
+            }
+
+            // Validate domain is a valid URL
+            try {
+                new URL(domain);
+            } catch (MalformedURLException e) {
+                LOG.errorf(e, "User %s: Invalid Cognito domain URL '%s', falling back to local logout", username, domain);
+                return performLocalLogout(username);
             }
 
             // Build logout redirect URI to the logged-out page
@@ -89,11 +111,42 @@ public class TokenResource {
                     clientId.get(),
                     URLEncoder.encode(logoutRedirectUri, StandardCharsets.UTF_8));
 
+            LOG.infof("User %s: Logging out via Cognito, redirecting to %s", username, domain + "/logout");
             return buildLogoutResponse(Response.seeOther(URI.create(cognitoLogoutUrl)));
         }
 
         // For non-Cognito providers, perform local logout
         return buildLogoutResponse(Response.ok(LOGGED_OUT_HTML));
+    }
+
+    private Response performLocalLogout(String username) {
+        LOG.infof("User %s: Performing local logout", username);
+        return buildLogoutResponse(Response.ok(LOGGED_OUT_HTML));
+    }
+
+    private String getUsernameForLogging() {
+        try {
+            return userService.getUserName();
+        } catch (Exception e) {
+            return "anonymous";
+        }
+    }
+
+    /**
+     * Exception mapper for logout-related exceptions.
+     * Handles any unexpected errors during logout by falling back to local logout HTML.
+     */
+    @ServerExceptionMapper
+    public Response mapLogoutException(Exception e) {
+        // Only handle exceptions from logout endpoints
+        if (e.getStackTrace().length > 0 &&
+            e.getStackTrace()[0].getMethodName().equals("logout") ||
+            e.getStackTrace()[0].getMethodName().equals("loggedOut")) {
+            LOG.errorf(e, "Unexpected error during logout, falling back to local logout page");
+            return buildLogoutResponse(Response.ok(LOGGED_OUT_HTML));
+        }
+        // Let other exceptions be handled by default handlers
+        return null;
     }
 
     /**

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -29,7 +29,6 @@ import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import com.redhat.ecosystemappeng.exploitiq.service.UserService;
-import io.quarkus.oidc.OidcSession;
 
 import java.net.URI;
 import java.net.URLEncoder;

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -72,14 +72,16 @@ public class TokenResource {
             // Build Cognito logout URL
             // Extract Cognito domain from auth server URL
             // auth-server-url format: https://cognito-idp.{region}.amazonaws.com/{user-pool-id}
-            // Cognito domain format: https://{region}{user-pool-id}.auth.{region}.amazoncognito.com
+            // user-pool-id format: {region}_{random-string}, e.g., eu-north-1_rIW9qmUNl
+            // Cognito domain format: https://{region-lowercase}{random-string-lowercase}.auth.{region}.amazoncognito.com
+            // Example: eu-north-1_rIW9qmUNl -> eu-north-1riw9qmunl.auth.eu-north-1.amazoncognito.com
             String authUrl = authServerUrl.get();
             String region = authUrl.substring(authUrl.indexOf("cognito-idp.") + 12, authUrl.indexOf(".amazonaws.com"));
             String userPoolId = authUrl.substring(authUrl.lastIndexOf("/") + 1);
 
-            // Build Cognito domain (remove hyphens from user pool ID for domain)
-            String cognitoDomain = String.format("https://%s%s.auth.%s.amazoncognito.com",
-                    region, userPoolId.replace("_", "").replace("-", "").toLowerCase(), region);
+            // Build Cognito domain: replace underscore with nothing, keep hyphens, convert to lowercase
+            String cognitoDomain = String.format("https://%s.auth.%s.amazoncognito.com",
+                    userPoolId.replace("_", "").toLowerCase(), region);
 
             // Build logout redirect URI (current app base URL)
             String logoutRedirectUri = uriInfo.getBaseUri().toString();

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -42,9 +42,6 @@ public class TokenResource {
     @Inject
     UserService userService;
 
-    @Inject
-    OidcSession oidcSession;
-
     @ConfigProperty(name = "quarkus.oidc.auth-server-url")
     Optional<String> authServerUrl;
 
@@ -72,8 +69,6 @@ public class TokenResource {
     @PermitAll
     public Response logout(@Context UriInfo uriInfo) {
         // Invalidate the OIDC session on the server side
-        oidcSession.logout().await().indefinitely();
-
         // Check if we're using AWS Cognito
         boolean isCognito = authServerUrl.isPresent() && authServerUrl.get().contains("cognito-idp");
 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -29,6 +29,7 @@ import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import com.redhat.ecosystemappeng.exploitiq.service.UserService;
+import io.quarkus.oidc.OidcSession;
 
 import java.net.URI;
 import java.net.URLEncoder;
@@ -40,6 +41,9 @@ public class TokenResource {
 
     @Inject
     UserService userService;
+
+    @Inject
+    OidcSession oidcSession;
 
     @ConfigProperty(name = "quarkus.oidc.auth-server-url")
     Optional<String> authServerUrl;
@@ -67,6 +71,9 @@ public class TokenResource {
     @Operation(hidden = true)
     @PermitAll
     public Response logout(@Context UriInfo uriInfo) {
+        // Invalidate the OIDC session on the server side
+        oidcSession.logout().await().indefinitely();
+
         // Check if we're using AWS Cognito
         boolean isCognito = authServerUrl.isPresent() && authServerUrl.get().contains("cognito-idp");
 
@@ -94,10 +101,10 @@ public class TokenResource {
             String cognitoDomain = String.format("https://%s.auth.%s.amazoncognito.com",
                     userPoolId.replace("_", "").toLowerCase(), region);
 
-            // Build logout redirect URI (application root, not API base)
-            // uriInfo.getBaseUri() returns https://host/api/v1/, we need https://host/
+            // Build logout redirect URI to the logged-out page
+            // uriInfo.getBaseUri() returns https://host/api/v1/, we need https://host/api/v1/user/logged-out
             URI baseUri = uriInfo.getBaseUri();
-            String logoutRedirectUri = baseUri.getScheme() + "://" + baseUri.getAuthority() + "/";
+            String logoutRedirectUri = baseUri.getScheme() + "://" + baseUri.getAuthority() + baseUri.getPath() + "user/logged-out";
 
             // Build Cognito logout URL with required parameters
             String cognitoLogoutUrl = String.format("%s/logout?client_id=%s&logout_uri=%s",
@@ -112,9 +119,25 @@ public class TokenResource {
         return buildLogoutResponse(Response.ok(LOGGED_OUT_HTML));
     }
 
+    /**
+     * Logged-out page endpoint.
+     * Displays the logout success message after Cognito completes its logout.
+     */
+    @GET
+    @Path("/logged-out")
+    @Produces(MediaType.TEXT_HTML)
+    @Operation(hidden = true)
+    @PermitAll
+    public Response loggedOut() {
+        return buildLogoutResponse(Response.ok(LOGGED_OUT_HTML));
+    }
+
     private Response buildLogoutResponse(Response.ResponseBuilder responseBuilder) {
         return responseBuilder
                 .header("Clear-Site-Data", "\"cookies\", \"storage\"")
+//                .header("Cache-Control", "no-cache, no-store, must-revalidate")
+//                .header("Pragma", "no-cache")
+//                .header("Expires", "0")
                 .build();
     }
 

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -58,6 +58,8 @@ public class TokenResource {
      * Logout endpoint with AWS Cognito support.
      * For Cognito (when auth-server-url contains cognito-idp), redirects to Cognito's logout endpoint.
      * For other OIDC providers, performs local logout with Clear-Site-Data header.
+     *
+     * NOTE: Cognito behind a reverse proxy is not currently supported.
      */
     @POST
     @Path("/logout")

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -83,8 +83,10 @@ public class TokenResource {
             String cognitoDomain = String.format("https://%s.auth.%s.amazoncognito.com",
                     userPoolId.replace("_", "").toLowerCase(), region);
 
-            // Build logout redirect URI (current app base URL)
-            String logoutRedirectUri = uriInfo.getBaseUri().toString();
+            // Build logout redirect URI (application root, not API base)
+            // uriInfo.getBaseUri() returns https://host/api/v1/, we need https://host/
+            URI baseUri = uriInfo.getBaseUri();
+            String logoutRedirectUri = baseUri.getScheme() + "://" + baseUri.getAuthority() + "/";
 
             // Build Cognito logout URL with required parameters
             String cognitoLogoutUrl = String.format("%s/logout?client_id=%s&logout_uri=%s",

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -108,11 +108,19 @@ public class TokenResource {
             // Build Cognito logout URL with required parameters
             String cognitoLogoutUrl = String.format("%s/logout?client_id=%s&logout_uri=%s",
                     domain,
-                    clientId.get(),
+                    URLEncoder.encode(clientId.get(), StandardCharsets.UTF_8),
                     URLEncoder.encode(logoutRedirectUri, StandardCharsets.UTF_8));
 
-            LOG.infof("User %s: Logging out via Cognito, redirecting to %s", username, domain + "/logout");
-            return buildLogoutResponse(Response.seeOther(URI.create(cognitoLogoutUrl)));
+            // Create URI with error handling
+            try {
+                URI cognitoUri = URI.create(cognitoLogoutUrl);
+                LOG.infof("User %s: Logging out via Cognito, redirecting to %s", username, domain + "/logout");
+                return buildLogoutResponse(Response.seeOther(cognitoUri));
+            } catch (IllegalArgumentException e) {
+                LOG.errorf(e, "User %s: Failed to create logout URI from '%s', falling back to local logout",
+                          username, cognitoLogoutUrl);
+                return performLocalLogout(username);
+            }
         }
 
         // For non-Cognito providers, perform local logout

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -29,6 +29,7 @@ import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 import com.redhat.ecosystemappeng.exploitiq.service.UserService;
 
 import java.net.MalformedURLException;
@@ -137,6 +138,17 @@ public class TokenResource {
             LOG.debugf(e, "Could not retrieve username for logging");
             return "anonymous";
         }
+    }
+
+    /**
+     * Exception mapper for logout-related exceptions.
+     * Catches any unexpected RuntimeException from logout endpoints to prevent
+     * them from being logged by BaseAuditEndpoint, which would cause confusion.
+     */
+    @ServerExceptionMapper
+    public Response mapLogoutException(RuntimeException e) {
+        LOG.errorf(e, "Unexpected error during logout, falling back to local logout page");
+        return buildLogoutResponse(Response.ok(LOGGED_OUT_HTML));
     }
 
     /**

--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -76,7 +76,16 @@ public class TokenResource {
             // Cognito domain format: https://{region-lowercase}{random-string-lowercase}.auth.{region}.amazoncognito.com
             // Example: eu-north-1_rIW9qmUNl -> eu-north-1riw9qmunl.auth.eu-north-1.amazoncognito.com
             String authUrl = authServerUrl.get();
-            String region = authUrl.substring(authUrl.indexOf("cognito-idp.") + 12, authUrl.indexOf(".amazonaws.com"));
+            int cognitoIdpIndex = authUrl.indexOf("cognito-idp.");
+            int amazonawsIndex = authUrl.indexOf(".amazonaws.com");
+
+            // Validate URL structure before extracting region
+            if (cognitoIdpIndex == -1 || amazonawsIndex == -1) {
+                // Fallback to local logout if URL doesn't match expected Cognito format
+                return createLocalLogoutResponse();
+            }
+
+            String region = authUrl.substring(cognitoIdpIndex + 12, amazonawsIndex);
             String userPoolId = authUrl.substring(authUrl.lastIndexOf("/") + 1);
 
             // Build Cognito domain: replace underscore with nothing, keep hyphens, convert to lowercase
@@ -100,6 +109,10 @@ public class TokenResource {
         }
 
         // For non-Cognito providers, perform local logout
+        return createLocalLogoutResponse();
+    }
+
+    private Response createLocalLogoutResponse() {
         return Response.ok(LOGGED_OUT_HTML)
                 .header("Clear-Site-Data", "\"cookies\", \"storage\"")
                 .build();

--- a/src/main/resources/META-INF/resources/error/403.html
+++ b/src/main/resources/META-INF/resources/error/403.html
@@ -21,10 +21,14 @@
     <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@6.1.0/patternfly.css" crossorigin="anonymous">
     <script>
         function logout() {
-            fetch('/api/v1/user/logout', { method: 'POST' })
-                .then(() => {
-                    window.location.href = "/";
-                });
+            // Create and submit a form to trigger logout endpoint
+            // This ensures cookies are cleared via Clear-Site-Data header
+            // and allows cross-origin redirects (e.g., to Cognito logout)
+            const form = document.createElement('form');
+            form.method = 'POST';
+            form.action = '/api/v1/user/logout';
+            document.body.appendChild(form);
+            form.submit();
         }
     </script>
 </head>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -150,7 +150,6 @@ quarkus.http.auth.permission.logout.policy=permit
 # Allow health endpoints (for monitoring)
 quarkus.http.auth.permission.management.paths=/health,/health/*
 quarkus.http.auth.permission.management.policy=permit
-quarkus.http.auth.permission.management.order=1
 
 
 # Allow dev UI in development mode

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -145,7 +145,6 @@ quarkus.oidc.authentication.java-script-auto-redirect=false
 exploitiq.security.public-logout-paths=/api/v1/user/logout,/api/v1/user/logged-out
 quarkus.http.auth.permission.logout.paths=${exploitiq.security.public-logout-paths}
 quarkus.http.auth.permission.logout.policy=permit
-quarkus.http.auth.permission.logout.order=1
 
 
 # Allow health endpoints (for monitoring)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -142,13 +142,16 @@ quarkus.oidc.authentication.java-script-auto-redirect=false
 # ==============================================================================
 
 # Allow logout for all authenticated users (even without roles)
-quarkus.http.auth.permission.logout.paths=/api/v1/user/logout
+exploitiq.security.public-logout-paths=/api/v1/user/logout,/api/v1/user/logged-out
+quarkus.http.auth.permission.logout.paths=${exploitiq.security.public-logout-paths}
 quarkus.http.auth.permission.logout.policy=permit
+quarkus.http.auth.permission.logout.order=1
 
 
 # Allow health endpoints (for monitoring)
 quarkus.http.auth.permission.management.paths=/health,/health/*
 quarkus.http.auth.permission.management.policy=permit
+quarkus.http.auth.permission.management.order=1
 
 
 # Allow dev UI in development mode
@@ -167,7 +170,8 @@ exploitiq.security.service-account-roles=system:serviceaccount:${NAMESPACE}:expl
 quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,${exploitiq.security.service-account-roles}
 quarkus.http.auth.permission.default.paths=/*
 quarkus.http.auth.permission.default.policy=role-policy
-# No order specified = lowest priority (applied last, after exceptions)
+#quarkus.http.auth.permission.default.order=1000
+# Higher order number = lower priority (applied last, after exceptions)
 
 
 # Smallrye Health UI is disabled by default in production environment

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -170,8 +170,7 @@ exploitiq.security.service-account-roles=system:serviceaccount:${NAMESPACE}:expl
 quarkus.http.auth.policy.role-policy.roles-allowed=exploit-iq-view,exploit-iq-prodsec,exploit-iq-admin,${exploitiq.security.service-account-roles}
 quarkus.http.auth.permission.default.paths=/*
 quarkus.http.auth.permission.default.policy=role-policy
-#quarkus.http.auth.permission.default.order=1000
-# Higher order number = lower priority (applied last, after exceptions)
+# No order specified = lowest priority (applied last, after exceptions)
 
 
 # Smallrye Health UI is disabled by default in production environment

--- a/src/main/webui/package-lock.json
+++ b/src/main/webui/package-lock.json
@@ -89,7 +89,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -375,6 +374,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
       "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -403,6 +403,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
       "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -417,6 +418,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
       "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -431,6 +433,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
       "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -2055,7 +2058,6 @@
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2071,7 +2073,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2150,7 +2151,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2452,7 +2452,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2642,7 +2641,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -3280,7 +3278,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5718,7 +5715,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5737,7 +5733,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5935,7 +5930,8 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -6574,7 +6570,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6833,7 +6828,6 @@
       "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-37.3.6.tgz",
       "integrity": "sha512-wVC8LKrZJLiSySNuJLRCB449qZTsPiRyzLlNoJwe21y+XA/a2HJbmJSeywmo8P153aX8viKe1H8ygDsTFXQhHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -6851,7 +6845,6 @@
       "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-37.3.6.tgz",
       "integrity": "sha512-Vi0dZvgmXmnCdoqc49WckeG5cMXnl7FTtqVhXu9JweA9cgCnkZabBd5mRvAjblb3Lo4j0HZCSPKHYWUPW70qZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -6868,7 +6861,6 @@
       "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-37.3.6.tgz",
       "integrity": "sha512-jdATFRWL1LUW/yEpKWx/aId2BiU2o1pPF9+Kh1TFISBduJoI4ZqvZD90H1QK4f/z50PikqiqiDECaKoKM1jfOQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -6886,7 +6878,6 @@
       "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-37.3.6.tgz",
       "integrity": "sha512-GOucnD63h14ScBuISC/nd1GBTEx6gIZfLE+0P0gyeH1poBKq0trTTvpQDvAMuGR8zICfEETG3ltmUMCwRrFyUg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -6971,7 +6962,6 @@
       "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-37.3.6.tgz",
       "integrity": "sha512-IkPo/W4AJ7bPu902TGER09OseR9ODm+FQAKfOBw4JsdEhZZ7BiG9zgd/25+x0r5EsTLu81CYGQVkBa+ZazcOlA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
@@ -6992,7 +6982,6 @@
       "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-37.3.6.tgz",
       "integrity": "sha512-aFgO6KokxPbUCPznZP5UPhOdI22pMuwDXKDt6eoQOnkVim66Ia+K95TQar2nwVKGYV5j26aKVf/n9blwphGJRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.21",
         "react-fast-compare": "^3.2.0",
@@ -7010,7 +6999,6 @@
       "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-37.3.6.tgz",
       "integrity": "sha512-Uf5bFQvqUsXCjqpvBW4LhrdrHkM6dBqxYgub6FCsBb86f84xZQ3vY7jFkg/JfvF0oGKMoWXYYrYLC1sk+fcWVA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-brush-container": "37.3.6",
@@ -7032,7 +7020,6 @@
       "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-37.3.6.tgz",
       "integrity": "sha512-+Oiw57d5nE+iq8As8RvepknzmNtKq1Gsc50u1X3IRd4jXtX8zqZrgXGlVZ+BP/tkLsWnGYVjKulwKBf2oaEUuw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -7065,7 +7052,6 @@
       "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-37.3.6.tgz",
       "integrity": "sha512-kgy/Azl5BxwlJAV0KDPGypv35TMrOD1J2ZxnJW2Wyyq+e8i0GGBIv5MoBzou64BRsDlS9V0CYRIjnkHgrBpB5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
@@ -7103,7 +7089,6 @@
       "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-37.3.6.tgz",
       "integrity": "sha512-vRRrhj3/ENqKVLdaBMzEmR83N6BOjox1bthYT1eJjN2H5SIK35bxn30IkiV/Pz3y627EqZe4TAWaxc0jiJlCiA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -7120,7 +7105,6 @@
       "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-37.3.6.tgz",
       "integrity": "sha512-Ke817uf/qFbN9jU7Dba7CrcHXYO5wAZuKKnyeHJmLDeQeFST0773xejnIuC+dBgZipjFr4KIbSd+VcUafFNE1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -7138,7 +7122,6 @@
       "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-37.3.6.tgz",
       "integrity": "sha512-tvdgAZ/HQWlo3KDDe0XAVbizHuaNMbgkkiF7zfA7Ww+3bHSs+0P9dsDtK2xP365D8gBCOv8pWmuzvKRhzNbqeA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -7172,7 +7155,6 @@
       "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-37.3.6.tgz",
       "integrity": "sha512-fp95zMTPXgW1cmTowzDXhn+KxePMVDrzU0lotsHQMdBV7eB+ioXdu9hORlx4VHmMYg2ihsGwRTF+VAZ7rGxphA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -7223,7 +7205,6 @@
       "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-37.3.6.tgz",
       "integrity": "sha512-ldod04RdqGJGH5p5eWXCofdTkbhZqIp3iwW7NpxSbMDLs8zPQIVvDFVtuJgMwQiC5vnIpbhMmxVeFbr8m64ZKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
@@ -7242,7 +7223,6 @@
       "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-37.3.6.tgz",
       "integrity": "sha512-vqaJS9noauOqDDBBAV9Ln9duOY/i17h1DCfCPAqhwPFyvFbwKvAub9zPTeYWAm/14VvWX5O/0yekFCVbcC7hjg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -7298,7 +7278,6 @@
       "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-37.3.6.tgz",
       "integrity": "sha512-qAAG0rMuK7A4EoJ4cyUk5wNdOW+HuCXNKPOko+hYK6wWOYXJvFhiglYyA85a695YyAXECc6JyJS/crm4IOEFag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "delaunay-find": "0.0.6",
         "lodash": "^4.17.19",
@@ -7318,7 +7297,6 @@
       "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-37.3.6.tgz",
       "integrity": "sha512-AGL+k20mI44OL5b0VgIxlmnNSefIoFmbbim5NraPmIxbtns9qQW/56ivIncJcYomBungIx99gUpsEpcQaMNHgQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -7336,7 +7314,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/main/webui/package-lock.json
+++ b/src/main/webui/package-lock.json
@@ -89,6 +89,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -374,7 +375,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
       "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -403,7 +403,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
       "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -418,7 +417,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
       "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -433,7 +431,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
       "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -2058,6 +2055,7 @@
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2073,6 +2071,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2151,6 +2150,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2452,6 +2452,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2641,6 +2642,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -3278,6 +3280,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5715,6 +5718,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5733,6 +5737,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5930,8 +5935,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -6570,6 +6574,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6828,6 +6833,7 @@
       "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-37.3.6.tgz",
       "integrity": "sha512-wVC8LKrZJLiSySNuJLRCB449qZTsPiRyzLlNoJwe21y+XA/a2HJbmJSeywmo8P153aX8viKe1H8ygDsTFXQhHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -6845,6 +6851,7 @@
       "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-37.3.6.tgz",
       "integrity": "sha512-Vi0dZvgmXmnCdoqc49WckeG5cMXnl7FTtqVhXu9JweA9cgCnkZabBd5mRvAjblb3Lo4j0HZCSPKHYWUPW70qZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -6861,6 +6868,7 @@
       "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-37.3.6.tgz",
       "integrity": "sha512-jdATFRWL1LUW/yEpKWx/aId2BiU2o1pPF9+Kh1TFISBduJoI4ZqvZD90H1QK4f/z50PikqiqiDECaKoKM1jfOQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -6878,6 +6886,7 @@
       "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-37.3.6.tgz",
       "integrity": "sha512-GOucnD63h14ScBuISC/nd1GBTEx6gIZfLE+0P0gyeH1poBKq0trTTvpQDvAMuGR8zICfEETG3ltmUMCwRrFyUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -6962,6 +6971,7 @@
       "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-37.3.6.tgz",
       "integrity": "sha512-IkPo/W4AJ7bPu902TGER09OseR9ODm+FQAKfOBw4JsdEhZZ7BiG9zgd/25+x0r5EsTLu81CYGQVkBa+ZazcOlA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
@@ -6982,6 +6992,7 @@
       "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-37.3.6.tgz",
       "integrity": "sha512-aFgO6KokxPbUCPznZP5UPhOdI22pMuwDXKDt6eoQOnkVim66Ia+K95TQar2nwVKGYV5j26aKVf/n9blwphGJRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.21",
         "react-fast-compare": "^3.2.0",
@@ -6999,6 +7010,7 @@
       "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-37.3.6.tgz",
       "integrity": "sha512-Uf5bFQvqUsXCjqpvBW4LhrdrHkM6dBqxYgub6FCsBb86f84xZQ3vY7jFkg/JfvF0oGKMoWXYYrYLC1sk+fcWVA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-brush-container": "37.3.6",
@@ -7020,6 +7032,7 @@
       "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-37.3.6.tgz",
       "integrity": "sha512-+Oiw57d5nE+iq8As8RvepknzmNtKq1Gsc50u1X3IRd4jXtX8zqZrgXGlVZ+BP/tkLsWnGYVjKulwKBf2oaEUuw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -7052,6 +7065,7 @@
       "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-37.3.6.tgz",
       "integrity": "sha512-kgy/Azl5BxwlJAV0KDPGypv35TMrOD1J2ZxnJW2Wyyq+e8i0GGBIv5MoBzou64BRsDlS9V0CYRIjnkHgrBpB5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
@@ -7089,6 +7103,7 @@
       "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-37.3.6.tgz",
       "integrity": "sha512-vRRrhj3/ENqKVLdaBMzEmR83N6BOjox1bthYT1eJjN2H5SIK35bxn30IkiV/Pz3y627EqZe4TAWaxc0jiJlCiA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -7105,6 +7120,7 @@
       "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-37.3.6.tgz",
       "integrity": "sha512-Ke817uf/qFbN9jU7Dba7CrcHXYO5wAZuKKnyeHJmLDeQeFST0773xejnIuC+dBgZipjFr4KIbSd+VcUafFNE1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -7122,6 +7138,7 @@
       "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-37.3.6.tgz",
       "integrity": "sha512-tvdgAZ/HQWlo3KDDe0XAVbizHuaNMbgkkiF7zfA7Ww+3bHSs+0P9dsDtK2xP365D8gBCOv8pWmuzvKRhzNbqeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -7155,6 +7172,7 @@
       "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-37.3.6.tgz",
       "integrity": "sha512-fp95zMTPXgW1cmTowzDXhn+KxePMVDrzU0lotsHQMdBV7eB+ioXdu9hORlx4VHmMYg2ihsGwRTF+VAZ7rGxphA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -7205,6 +7223,7 @@
       "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-37.3.6.tgz",
       "integrity": "sha512-ldod04RdqGJGH5p5eWXCofdTkbhZqIp3iwW7NpxSbMDLs8zPQIVvDFVtuJgMwQiC5vnIpbhMmxVeFbr8m64ZKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
@@ -7223,6 +7242,7 @@
       "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-37.3.6.tgz",
       "integrity": "sha512-vqaJS9noauOqDDBBAV9Ln9duOY/i17h1DCfCPAqhwPFyvFbwKvAub9zPTeYWAm/14VvWX5O/0yekFCVbcC7hjg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -7278,6 +7298,7 @@
       "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-37.3.6.tgz",
       "integrity": "sha512-qAAG0rMuK7A4EoJ4cyUk5wNdOW+HuCXNKPOko+hYK6wWOYXJvFhiglYyA85a695YyAXECc6JyJS/crm4IOEFag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "delaunay-find": "0.0.6",
         "lodash": "^4.17.19",
@@ -7297,6 +7318,7 @@
       "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-37.3.6.tgz",
       "integrity": "sha512-AGL+k20mI44OL5b0VgIxlmnNSefIoFmbbim5NraPmIxbtns9qQW/56ivIncJcYomBungIx99gUpsEpcQaMNHgQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -7314,6 +7336,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResourceLogoutCognitoTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResourceLogoutCognitoTest.java
@@ -7,6 +7,8 @@ package com.redhat.ecosystemappeng.exploitiq.rest;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,7 +59,7 @@ class TokenResourceLogoutCognitoTest {
                 .header("Location");
 
         // Verify logout_uri is URL-encoded (contains %3A for : and %2F for /)
-        assert location.contains("logout_uri=http%3A%2F%2F");
+        assertThat(location, containsString("logout_uri=http%3A%2F%2F"));
     }
 
     @Test
@@ -72,7 +74,9 @@ class TokenResourceLogoutCognitoTest {
                 .header("Location");
 
         // Verify the logout_uri parameter points to /api/v1/user/logged-out
-        assert location.contains("user%2Flogged-out") || location.contains("user/logged-out");
+        assertThat(location, anyOf(
+                containsString("user%2Flogged-out"),
+                containsString("user/logged-out")));
     }
 
     @Test

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResourceLogoutCognitoTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResourceLogoutCognitoTest.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.rest;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.restassured.RestAssured;
+
+import java.util.Map;
+
+/**
+ * Tests for {@link TokenResource} logout endpoint with AWS Cognito configuration.
+ * Verifies that Cognito logout redirects to the correct URL with required parameters.
+ */
+@QuarkusTest
+@TestProfile(TokenResourceLogoutCognitoTest.CognitoProfile.class)
+class TokenResourceLogoutCognitoTest {
+
+    @BeforeEach
+    void configureRestAssured() {
+        RestApiTestFixture.configureRestAssuredIfExternal();
+    }
+
+    @Test
+    void logoutWithCognitoRedirectsToCognitoLogoutEndpoint() {
+        RestAssured.given()
+                .redirects().follow(false)
+                .when()
+                .post("/api/v1/user/logout")
+                .then()
+                .statusCode(303)
+                .header("Location", containsString("https://test-domain.auth.us-east-1.amazoncognito.com/logout"))
+                .header("Location", containsString("client_id=test-client-id"))
+                .header("Location", containsString("logout_uri="))
+                .header("Clear-Site-Data", equalTo("\"cookies\", \"storage\""));
+    }
+
+    @Test
+    void logoutWithCognitoEncodesLogoutUriParameter() {
+        String location = RestAssured.given()
+                .redirects().follow(false)
+                .when()
+                .post("/api/v1/user/logout")
+                .then()
+                .statusCode(303)
+                .extract()
+                .header("Location");
+
+        // Verify logout_uri is URL-encoded (contains %3A for : and %2F for /)
+        assert location.contains("logout_uri=http%3A%2F%2F");
+    }
+
+    @Test
+    void logoutWithCognitoRedirectsToLoggedOutPage() {
+        String location = RestAssured.given()
+                .redirects().follow(false)
+                .when()
+                .post("/api/v1/user/logout")
+                .then()
+                .statusCode(303)
+                .extract()
+                .header("Location");
+
+        // Verify the logout_uri parameter points to /api/v1/user/logged-out
+        assert location.contains("user%2Flogged-out") || location.contains("user/logged-out");
+    }
+
+    @Test
+    void logoutWithCognitoHandlesTrailingSlashInDomain() {
+        // This test uses a profile with trailing slash in cognito.domain
+        // The implementation should strip it
+        RestAssured.given()
+                .redirects().follow(false)
+                .when()
+                .post("/api/v1/user/logout")
+                .then()
+                .statusCode(303)
+                .header("Location", containsString("amazoncognito.com/logout"))
+                .header("Location", containsString("/logout?")); // Verify no double slash before query params
+    }
+
+    @Test
+    void loggedOutPageReturnsSuccessHtml() {
+        RestAssured.given()
+                .when()
+                .get("/api/v1/user/logged-out")
+                .then()
+                .statusCode(200)
+                .contentType("text/html")
+                .body(containsString("Successfully Logged Out"))
+                .body(containsString("ExploitIQ"))
+                .body(containsString("Login Again"))
+                .header("Clear-Site-Data", equalTo("\"cookies\", \"storage\""));
+    }
+
+    public static class CognitoProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.oidc.enabled", "false",
+                    "quarkus.oidc.auth-server-url", "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TestPool",
+                    "quarkus.oidc.client-id", "test-client-id",
+                    "cognito.domain", "https://test-domain.auth.us-east-1.amazoncognito.com/"
+            );
+        }
+    }
+}

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResourceLogoutErrorHandlingTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResourceLogoutErrorHandlingTest.java
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.rest;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.restassured.RestAssured;
+
+import java.util.Map;
+
+/**
+ * Test suite for {@link TokenResource} logout endpoint error handling.
+ * Each nested test class has its own test profile to test different error scenarios.
+ *
+ * NOTE: The scenario "cognito.domain present but client-id missing" cannot be tested here
+ * because quarkus.oidc.client-id has a default value in application.properties and Quarkus
+ * requires it to be non-empty when OIDC is configured. The code handles this case with
+ * {@code if (cognitoDomain.isPresent() && clientId.isPresent())} guard.
+ */
+class TokenResourceLogoutErrorHandlingTest {
+
+    /**
+     * Test profile for empty domain scenario
+     */
+    @QuarkusTest
+    @TestProfile(EmptyDomainProfile.class)
+    static class EmptyDomainTest {
+
+        @BeforeEach
+        void configureRestAssured() {
+            RestApiTestFixture.configureRestAssuredIfExternal();
+        }
+
+        @Test
+        void logoutWithWhitespaceOnlyDomainFallsBackToLocalLogout() {
+            RestAssured.given()
+                    .redirects().follow(false)
+                    .when()
+                    .post("/api/v1/user/logout")
+                    .then()
+                    .statusCode(200)
+                    .contentType("text/html")
+                    .body(containsString("Successfully Logged Out"))
+                    .header("Clear-Site-Data", equalTo("\"cookies\", \"storage\""));
+        }
+    }
+
+    public static class EmptyDomainProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.oidc.enabled", "false",
+                    "quarkus.oidc.client-id", "test-client-id",
+                    "cognito.domain", "   "  // Whitespace only
+            );
+        }
+    }
+
+    /**
+     * Test profile for malformed URL scenario
+     */
+    @QuarkusTest
+    @TestProfile(MalformedDomainProfile.class)
+    static class MalformedDomainTest {
+
+        @BeforeEach
+        void configureRestAssured() {
+            RestApiTestFixture.configureRestAssuredIfExternal();
+        }
+
+        @Test
+        void logoutWithInvalidUrlFallsBackToLocalLogout() {
+            RestAssured.given()
+                    .redirects().follow(false)
+                    .when()
+                    .post("/api/v1/user/logout")
+                    .then()
+                    .statusCode(200)
+                    .contentType("text/html")
+                    .body(containsString("Successfully Logged Out"))
+                    .header("Clear-Site-Data", equalTo("\"cookies\", \"storage\""));
+        }
+    }
+
+    public static class MalformedDomainProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.oidc.enabled", "false",
+                    "quarkus.oidc.client-id", "test-client-id",
+                    "cognito.domain", "not-a-valid-url"  // Invalid URL
+            );
+        }
+    }
+
+    /**
+     * Test profile for domain with special characters
+     */
+    @QuarkusTest
+    @TestProfile(SpecialCharsDomainProfile.class)
+    static class SpecialCharsDomainTest {
+
+        @BeforeEach
+        void configureRestAssured() {
+            RestApiTestFixture.configureRestAssuredIfExternal();
+        }
+
+        @Test
+        void logoutWithSpecialCharactersInDomainHandledCorrectly() {
+            // This should either work or fall back gracefully
+            RestAssured.given()
+                    .redirects().follow(false)
+                    .when()
+                    .post("/api/v1/user/logout")
+                    .then()
+                    // Accept either redirect (303) or local logout (200)
+                    .statusCode(org.hamcrest.Matchers.anyOf(
+                            org.hamcrest.Matchers.equalTo(200),
+                            org.hamcrest.Matchers.equalTo(303)))
+                    .header("Clear-Site-Data", equalTo("\"cookies\", \"storage\""));
+        }
+    }
+
+    public static class SpecialCharsDomainProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.oidc.enabled", "false",
+                    "quarkus.oidc.client-id", "test-client-id",
+                    "cognito.domain", "https://test-domain.auth.us-east-1.amazoncognito.com"
+            );
+        }
+    }
+}

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResourceLogoutMissingConfigTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResourceLogoutMissingConfigTest.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.rest;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.restassured.RestAssured;
+
+import java.util.Map;
+
+/**
+ * Tests for {@link TokenResource} logout endpoint with missing or minimal OIDC configuration.
+ * Verifies fallback behavior when configuration is incomplete.
+ */
+@QuarkusTest
+@TestProfile(TokenResourceLogoutMissingConfigTest.MinimalConfigProfile.class)
+class TokenResourceLogoutMissingConfigTest {
+
+    @BeforeEach
+    void configureRestAssured() {
+        RestApiTestFixture.configureRestAssuredIfExternal();
+    }
+
+    @Test
+    void logoutWithoutAnyOidcConfigReturnsLocalLogout() {
+        RestAssured.given()
+                .when()
+                .post("/api/v1/user/logout")
+                .then()
+                .statusCode(200)
+                .contentType("text/html")
+                .body(containsString("Successfully Logged Out"))
+                .header("Clear-Site-Data", equalTo("\"cookies\", \"storage\""));
+    }
+
+    @Test
+    void loggedOutPageWorksWithoutOidcConfig() {
+        RestAssured.given()
+                .when()
+                .get("/api/v1/user/logged-out")
+                .then()
+                .statusCode(200)
+                .contentType("text/html")
+                .body(containsString("Successfully Logged Out"))
+                .header("Clear-Site-Data", equalTo("\"cookies\", \"storage\""));
+    }
+
+    public static class MinimalConfigProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.oidc.enabled", "false"
+                    // No auth-server-url, client-id, or cognito.domain
+            );
+        }
+    }
+}

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResourceLogoutNonCognitoTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResourceLogoutNonCognitoTest.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.rest;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.restassured.RestAssured;
+
+import java.util.Map;
+
+/**
+ * Tests for {@link TokenResource} logout endpoint with non-Cognito OIDC provider.
+ * Verifies that non-Cognito logout performs local logout without redirect.
+ */
+@QuarkusTest
+@TestProfile(TokenResourceLogoutNonCognitoTest.NonCognitoProfile.class)
+class TokenResourceLogoutNonCognitoTest {
+
+    @BeforeEach
+    void configureRestAssured() {
+        RestApiTestFixture.configureRestAssuredIfExternal();
+    }
+
+    @Test
+    void logoutWithoutCognitoReturnsLocalLogoutHtml() {
+        RestAssured.given()
+                .when()
+                .post("/api/v1/user/logout")
+                .then()
+                .statusCode(200)
+                .contentType("text/html")
+                .body(containsString("Successfully Logged Out"))
+                .body(containsString("ExploitIQ"))
+                .body(containsString("Login Again"))
+                .header("Clear-Site-Data", equalTo("\"cookies\", \"storage\""));
+    }
+
+    @Test
+    void logoutWithoutCognitoDoesNotRedirect() {
+        RestAssured.given()
+                .redirects().follow(false)
+                .when()
+                .post("/api/v1/user/logout")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void loggedOutPageReturnsSuccessHtml() {
+        RestAssured.given()
+                .when()
+                .get("/api/v1/user/logged-out")
+                .then()
+                .statusCode(200)
+                .contentType("text/html")
+                .body(containsString("Successfully Logged Out"))
+                .header("Clear-Site-Data", equalTo("\"cookies\", \"storage\""));
+    }
+
+    public static class NonCognitoProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.oidc.enabled", "false",
+                    "quarkus.oidc.auth-server-url", "https://keycloak.example.com/realms/test",
+                    "quarkus.oidc.client-id", "test-client-id"
+                    // cognito.domain is NOT set
+            );
+        }
+    }
+}

--- a/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResourceLogoutPathConstructionTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResourceLogoutPathConstructionTest.java
@@ -1,0 +1,126 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, Red Hat Inc. & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.redhat.ecosystemappeng.exploitiq.rest;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.restassured.RestAssured;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Tests for {@link TokenResource} logout URL path construction.
+ * Verifies that logout redirect URIs are correctly built regardless of baseUri format.
+ */
+@QuarkusTest
+@TestProfile(TokenResourceLogoutPathConstructionTest.PathConstructionProfile.class)
+class TokenResourceLogoutPathConstructionTest {
+
+    @BeforeEach
+    void configureRestAssured() {
+        RestApiTestFixture.configureRestAssuredIfExternal();
+    }
+
+    @Test
+    void logoutRedirectUriIsCorrectlyConstructed() {
+        String location = RestAssured.given()
+                .redirects().follow(false)
+                .when()
+                .post("/api/v1/user/logout")
+                .then()
+                .statusCode(303)
+                .header("Clear-Site-Data", equalTo("\"cookies\", \"storage\""))
+                .extract()
+                .header("Location");
+
+        // Verify the location contains the Cognito logout endpoint
+        assertTrue(location.contains("https://test-domain.auth.us-east-1.amazoncognito.com/logout"),
+                "Location should contain Cognito logout URL");
+
+        // Verify client_id parameter is present
+        assertTrue(location.contains("client_id=test-client-id"),
+                "Location should contain client_id parameter");
+
+        // Verify logout_uri parameter is present and encoded
+        assertTrue(location.contains("logout_uri="),
+                "Location should contain logout_uri parameter");
+
+        // Decode the logout_uri to verify it's correctly formed
+        int logoutUriStart = location.indexOf("logout_uri=") + "logout_uri=".length();
+        String encodedUri = location.substring(logoutUriStart);
+        String decodedUri = URLDecoder.decode(encodedUri, StandardCharsets.UTF_8);
+
+        // Should contain /api/v1/user/logged-out (not /api/v1user/logged-out or double slashes)
+        assertTrue(decodedUri.contains("/api/v1/user/logged-out"),
+                "Decoded logout_uri should be '/api/v1/user/logged-out' but was: " + decodedUri);
+
+        // Should NOT contain double slashes (except in https://)
+        String pathPart = decodedUri.substring(decodedUri.indexOf("://") + 3);
+        assertTrue(!pathPart.contains("//"),
+                "Path should not contain double slashes: " + pathPart);
+    }
+
+    @Test
+    void logoutRedirectUriHandlesTrailingSlashInBaseUri() {
+        // Even if baseUri has trailing slash, the constructed URI should be valid
+        String location = RestAssured.given()
+                .redirects().follow(false)
+                .when()
+                .post("/api/v1/user/logout")
+                .then()
+                .statusCode(303)
+                .extract()
+                .header("Location");
+
+        int logoutUriStart = location.indexOf("logout_uri=") + "logout_uri=".length();
+        String encodedUri = location.substring(logoutUriStart);
+        String decodedUri = URLDecoder.decode(encodedUri, StandardCharsets.UTF_8);
+
+        // Verify correct path format
+        assertTrue(decodedUri.matches("https?://[^/]+/api/v1/user/logged-out"),
+                "Logout URI should match expected format: " + decodedUri);
+    }
+
+    @Test
+    void cognitoDomainTrailingSlashIsStripped() {
+        String location = RestAssured.given()
+                .redirects().follow(false)
+                .when()
+                .post("/api/v1/user/logout")
+                .then()
+                .statusCode(303)
+                .extract()
+                .header("Location");
+
+        // Should contain /logout? (not //logout?)
+        assertTrue(location.contains(".com/logout?"),
+                "Cognito domain trailing slash should be stripped: " + location);
+
+        assertTrue(!location.contains(".com//logout"),
+                "Should not have double slash before /logout: " + location);
+    }
+
+    public static class PathConstructionProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.oidc.enabled", "false",
+                    "quarkus.oidc.client-id", "test-client-id",
+                    "cognito.domain", "https://test-domain.auth.us-east-1.amazoncognito.com/"  // With trailing slash
+            );
+        }
+    }
+}


### PR DESCRIPTION
  Quarkus OIDC's built-in logout sends id_token_hint and post_logout_redirect_uri,
  but AWS Cognito requires client_id and logout_uri parameters instead.