### PR TITLE
Fix logout back

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
+++ b/src/main/java/com/redhat/ecosystemappeng/exploitiq/rest/TokenResource.java
@@ -53,6 +53,9 @@ public class TokenResource {
     public Response logout() {
         return Response.ok(LOGGED_OUT_HTML)
                 .header("Clear-Site-Data", "\"cookies\", \"storage\"")
+                .header("Cache-Control", "no-cache, no-store, must-revalidate")
+                .header("Pragma", "no-cache")
+                .header("Expires", "0")
                 .build();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,7 @@ quarkus.rest-client.component-syncer.url=http://job-sink.knative-eventing.svc.cl
 quarkus.smallrye-openapi.store-schema-directory=target/generated/openapi
 
 quarkus.swagger-ui.always-include=${INCLUDE_SWAGGER_UI:true}
-quarkus.http.filter.others.header.Cache-Control=no-cache
+quarkus.http.filter.others.header.Cache-Control=no-store, no-cache, must-revalidate
 quarkus.http.filter.others.matches=/.*
 quarkus.http.filter.others.methods=GET
 quarkus.http.filter.others.order=0


### PR DESCRIPTION
## Bug Description

  After logout, pressing the browser's back button displayed cached authenticated pages. While the session was properly invalidated server-side (any action would redirect to login),
  showing stale content was confusing and appeared insecure to users.

## Fix

  Strengthened cache control to `no-store, no-cache, must-revalidate` to prevent browsers from caching authenticated pages entirely.